### PR TITLE
Reduce SQL calls when incrementing/decrementing run counters

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -97,9 +97,11 @@ module Bulkrax
       end
 
       if errors.present?
-        # rubocop:disable Rails/SkipsModelValidations
-        importer_run.increment!(:failed_relationships, number_of_failures)
-        # rubocop:enable Rails/SkipsModelValidations
+        ImporterRun.connection.execute(<<-SQL)
+          UPDATE bulkrax_importer_runs
+          SET failed_relationships = COALESCE(failed_relationships, 0) + #{number_of_failures}
+          WHERE id = #{importer_run_id}
+        SQL
 
         parent_entry&.set_status_info(errors.last, importer_run)
 
@@ -107,9 +109,11 @@ module Bulkrax
         reschedule({ parent_identifier: parent_identifier, importer_run_id: importer_run_id })
         return false # stop current job from continuing to run after rescheduling
       else
-        # rubocop:disable Rails/SkipsModelValidations
-        Bulkrax::ImporterRun.find(importer_run_id).increment!(:processed_relationships, number_of_successes)
-        # rubocop:enable Rails/SkipsModelValidations
+        ImporterRun.connection.execute(<<-SQL)
+          UPDATE bulkrax_importer_runs
+          SET processed_relationships = COALESCE(processed_relationships, 0) + #{number_of_successes}
+          WHERE id = #{importer_run_id}
+        SQL
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -97,7 +97,9 @@ module Bulkrax
       end
 
       if errors.present?
+        # rubocop:disable Rails/SkipsModelValidations
         ImporterRun.update_counters(importer_run_id, failed_relationships: number_of_failures)
+        # rubocop:enable Rails/SkipsModelValidations
 
         parent_entry&.set_status_info(errors.last, importer_run)
 
@@ -105,7 +107,9 @@ module Bulkrax
         reschedule({ parent_identifier: parent_identifier, importer_run_id: importer_run_id })
         return false # stop current job from continuing to run after rescheduling
       else
+        # rubocop:disable Rails/SkipsModelValidations
         ImporterRun.update_counters(importer_run_id, processed_relationships: number_of_successes)
+        # rubocop:enable Rails/SkipsModelValidations
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -97,11 +97,7 @@ module Bulkrax
       end
 
       if errors.present?
-        ImporterRun.connection.execute(<<-SQL)
-          UPDATE bulkrax_importer_runs
-          SET failed_relationships = COALESCE(failed_relationships, 0) + #{number_of_failures}
-          WHERE id = #{importer_run_id}
-        SQL
+        ImporterRun.update_counters(importer_run_id, failed_relationships: number_of_failures)
 
         parent_entry&.set_status_info(errors.last, importer_run)
 
@@ -109,11 +105,7 @@ module Bulkrax
         reschedule({ parent_identifier: parent_identifier, importer_run_id: importer_run_id })
         return false # stop current job from continuing to run after rescheduling
       else
-        ImporterRun.connection.execute(<<-SQL)
-          UPDATE bulkrax_importer_runs
-          SET processed_relationships = COALESCE(processed_relationships, 0) + #{number_of_successes}
-          WHERE id = #{importer_run_id}
-        SQL
+        ImporterRun.update_counters(importer_run_id, processed_relationships: number_of_successes)
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/app/jobs/bulkrax/delete_job.rb
+++ b/app/jobs/bulkrax/delete_job.rb
@@ -8,7 +8,7 @@ module Bulkrax
     def perform(entry, importer_run)
       obj = entry.factory.find
       obj&.delete
-      ImporterRun.find(importer_run.id).increment!(:deleted_records)
+      ImporterRun.increment_counter(:deleted_records, importer_run.id)
       ImporterRun.find(importer_run.id).decrement!(:enqueued_records)
       entry.save!
       entry.importer.current_run = ImporterRun.find(importer_run.id)

--- a/app/jobs/bulkrax/delete_job.rb
+++ b/app/jobs/bulkrax/delete_job.rb
@@ -9,7 +9,7 @@ module Bulkrax
       obj = entry.factory.find
       obj&.delete
       ImporterRun.increment_counter(:deleted_records, importer_run.id)
-      ImporterRun.find(importer_run.id).decrement!(:enqueued_records)
+      ImporterRun.decrement_counter(:enqueued_records, importer_run.id)
       entry.save!
       entry.importer.current_run = ImporterRun.find(importer_run.id)
       entry.importer.record_status

--- a/app/jobs/bulkrax/delete_job.rb
+++ b/app/jobs/bulkrax/delete_job.rb
@@ -4,17 +4,17 @@ module Bulkrax
   class DeleteJob < ApplicationJob
     queue_as :import
 
-    # rubocop:disable Rails/SkipsModelValidations
     def perform(entry, importer_run)
       obj = entry.factory.find
       obj&.delete
+      # rubocop:disable Rails/SkipsModelValidations
       ImporterRun.increment_counter(:deleted_records, importer_run.id)
       ImporterRun.decrement_counter(:enqueued_records, importer_run.id)
+      # rubocop:enable Rails/SkipsModelValidations
       entry.save!
       entry.importer.current_run = ImporterRun.find(importer_run.id)
       entry.importer.record_status
       entry.set_status_info("Deleted", ImporterRun.find(importer_run.id))
     end
-    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/app/jobs/bulkrax/export_work_job.rb
+++ b/app/jobs/bulkrax/export_work_job.rb
@@ -12,16 +12,16 @@ module Bulkrax
         entry.save
       rescue StandardError
         # rubocop:disable Rails/SkipsModelValidations
-        exporter_run.increment!(:failed_records)
+        ExporterRun.increment_counter(:failed_records, args[1])
         exporter_run.decrement!(:enqueued_records) unless exporter_run.enqueued_records <= 0
         raise
       else
         if entry.failed?
-          exporter_run.increment!(:failed_records)
+          ExporterRun.increment_counter(:failed_records, args[1])
           exporter_run.decrement!(:enqueued_records) unless exporter_run.enqueued_records <= 0
           raise entry.reload.current_status.error_class.constantize
         else
-          exporter_run.increment!(:processed_records)
+          ExporterRun.increment_counter(:processed_records, args[1])
           exporter_run.decrement!(:enqueued_records) unless exporter_run.enqueued_records <= 0
         end
         # rubocop:enable Rails/SkipsModelValidations

--- a/app/jobs/bulkrax/export_work_job.rb
+++ b/app/jobs/bulkrax/export_work_job.rb
@@ -13,16 +13,16 @@ module Bulkrax
       rescue StandardError
         # rubocop:disable Rails/SkipsModelValidations
         ExporterRun.increment_counter(:failed_records, args[1])
-        exporter_run.decrement!(:enqueued_records) unless exporter_run.enqueued_records <= 0
+        ExporterRun.decrement_counter(:enqueued_records, args[1]) unless exporter_run.reload.enqueued_records <= 0
         raise
       else
         if entry.failed?
           ExporterRun.increment_counter(:failed_records, args[1])
-          exporter_run.decrement!(:enqueued_records) unless exporter_run.enqueued_records <= 0
+          ExporterRun.decrement_counter(:enqueued_records, args[1]) unless exporter_run.reload.enqueued_records <= 0
           raise entry.reload.current_status.error_class.constantize
         else
           ExporterRun.increment_counter(:processed_records, args[1])
-          exporter_run.decrement!(:enqueued_records) unless exporter_run.enqueued_records <= 0
+          ExporterRun.decrement_counter(:enqueued_records, args[1]) unless exporter_run.reload.enqueued_records <= 0
         end
         # rubocop:enable Rails/SkipsModelValidations
       end

--- a/app/jobs/bulkrax/import_collection_job.rb
+++ b/app/jobs/bulkrax/import_collection_job.rb
@@ -10,12 +10,12 @@ module Bulkrax
       begin
         entry.build
         entry.save!
-        ImporterRun.find(args[1]).increment!(:processed_records)
-        ImporterRun.find(args[1]).increment!(:processed_collections)
+        ImporterRun.increment_counter(:processed_records, args[1])
+        ImporterRun.increment_counter(:processed_collections, args[1])
         ImporterRun.find(args[1]).decrement!(:enqueued_records) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
       rescue => e
-        ImporterRun.find(args[1]).increment!(:failed_records)
-        ImporterRun.find(args[1]).increment!(:failed_collections)
+        ImporterRun.increment_counter(:failed_records, args[1])
+        ImporterRun.increment_counter(:failed_collections, args[1])
         ImporterRun.find(args[1]).decrement!(:enqueued_records) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
         raise e
       end

--- a/app/jobs/bulkrax/import_collection_job.rb
+++ b/app/jobs/bulkrax/import_collection_job.rb
@@ -12,11 +12,11 @@ module Bulkrax
         entry.save!
         ImporterRun.increment_counter(:processed_records, args[1])
         ImporterRun.increment_counter(:processed_collections, args[1])
-        ImporterRun.find(args[1]).decrement!(:enqueued_records) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
+        ImporterRun.decrement_counter(:enqueued_records, args[1]) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
       rescue => e
         ImporterRun.increment_counter(:failed_records, args[1])
         ImporterRun.increment_counter(:failed_collections, args[1])
-        ImporterRun.find(args[1]).decrement!(:enqueued_records) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
+        ImporterRun.decrement_counter(:enqueued_records, args[1]) unless ImporterRun.find(args[1]).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
         raise e
       end
       entry.importer.current_run = ImporterRun.find(args[1])

--- a/app/jobs/bulkrax/import_file_set_job.rb
+++ b/app/jobs/bulkrax/import_file_set_job.rb
@@ -26,7 +26,7 @@ module Bulkrax
         ImporterRun.increment_counter(:failed_records, importer_run_id)
         ImporterRun.increment_counter(:failed_file_sets, importer_run_id)
       end
-      ImporterRun.find(importer_run_id).decrement!(:enqueued_records) unless ImporterRun.find(importer_run_id).enqueued_records <= 0 # rubocop:disable Rails/SkipsModelValidations
+      ImporterRun.decrement_counter(:enqueued_records, importer_run_id) unless ImporterRun.find(importer_run_id).enqueued_records <= 0 # rubocop:disable Rails/SkipsModelValidations
       entry.save!
       entry.importer.current_run = ImporterRun.find(importer_run_id)
       entry.importer.record_status
@@ -38,7 +38,7 @@ module Bulkrax
       if entry.import_attempts < 5
         ImportFileSetJob.set(wait: (entry.import_attempts + 1).minutes).perform_later(entry_id, importer_run_id)
       else
-        ImporterRun.find(importer_run_id).decrement!(:enqueued_records) # rubocop:disable Rails/SkipsModelValidations
+        ImporterRun.decrement_counter(:enqueued_records, importer_run_id) # rubocop:disable Rails/SkipsModelValidations
         entry.set_status_info(e)
       end
     end

--- a/app/jobs/bulkrax/import_file_set_job.rb
+++ b/app/jobs/bulkrax/import_file_set_job.rb
@@ -20,11 +20,13 @@ module Bulkrax
 
       entry.build
       if entry.succeeded?
+        # rubocop:disable Rails/SkipsModelValidations
         ImporterRun.increment_counter(:processed_records, importer_run_id)
         ImporterRun.increment_counter(:processed_file_sets, importer_run_id)
       else
         ImporterRun.increment_counter(:failed_records, importer_run_id)
         ImporterRun.increment_counter(:failed_file_sets, importer_run_id)
+        # rubocop:enable Rails/SkipsModelValidations
       end
       ImporterRun.decrement_counter(:enqueued_records, importer_run_id) unless ImporterRun.find(importer_run_id).enqueued_records <= 0 # rubocop:disable Rails/SkipsModelValidations
       entry.save!

--- a/app/jobs/bulkrax/import_file_set_job.rb
+++ b/app/jobs/bulkrax/import_file_set_job.rb
@@ -20,13 +20,11 @@ module Bulkrax
 
       entry.build
       if entry.succeeded?
-        # rubocop:disable Rails/SkipsModelValidations
-        ImporterRun.find(importer_run_id).increment!(:processed_records)
-        ImporterRun.find(importer_run_id).increment!(:processed_file_sets)
+        ImporterRun.increment_counter(:processed_records, importer_run_id)
+        ImporterRun.increment_counter(:processed_file_sets, importer_run_id)
       else
-        ImporterRun.find(importer_run_id).increment!(:failed_records)
-        ImporterRun.find(importer_run_id).increment!(:failed_file_sets)
-        # rubocop:enable Rails/SkipsModelValidations
+        ImporterRun.increment_counter(:failed_records, importer_run_id)
+        ImporterRun.increment_counter(:failed_file_sets, importer_run_id)
       end
       ImporterRun.find(importer_run_id).decrement!(:enqueued_records) unless ImporterRun.find(importer_run_id).enqueued_records <= 0 # rubocop:disable Rails/SkipsModelValidations
       entry.save!

--- a/app/jobs/bulkrax/import_work_job.rb
+++ b/app/jobs/bulkrax/import_work_job.rb
@@ -32,7 +32,7 @@ module Bulkrax
         ImporterRun.increment_counter(:failed_works, run_id)
       end
       # Regardless of completion or not, we want to decrement the enqueued records.
-      ImporterRun.find(run_id).decrement!(:enqueued_records) unless ImporterRun.find(run_id).enqueued_records <= 0
+      ImporterRun.decrement_counter(:enqueued_records, run_id) unless ImporterRun.find(run_id).enqueued_records <= 0
 
       entry.save!
       entry.importer.current_run = ImporterRun.find(run_id)

--- a/app/jobs/bulkrax/import_work_job.rb
+++ b/app/jobs/bulkrax/import_work_job.rb
@@ -23,13 +23,13 @@ module Bulkrax
       entry = Entry.find(entry_id)
       entry.build
       if entry.status == "Complete"
-        ImporterRun.find(run_id).increment!(:processed_records)
-        ImporterRun.find(run_id).increment!(:processed_works)
+        ImporterRun.increment_counter(:processed_records, run_id)
+        ImporterRun.increment_counter(:processed_works, run_id)
       else
         # do not retry here because whatever parse error kept you from creating a work will likely
         # keep preventing you from doing so.
-        ImporterRun.find(run_id).increment!(:failed_records)
-        ImporterRun.find(run_id).increment!(:failed_works)
+        ImporterRun.increment_counter(:failed_records, run_id)
+        ImporterRun.increment_counter(:failed_works, run_id)
       end
       # Regardless of completion or not, we want to decrement the enqueued records.
       ImporterRun.find(run_id).decrement!(:enqueued_records) unless ImporterRun.find(run_id).enqueued_records <= 0

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -270,7 +270,7 @@ module Bulkrax
       current_run.invalid_records ||= ""
       current_run.invalid_records += message
       current_run.save
-      ImporterRun.find(current_run.id).increment!(:failed_records)
+      ImporterRun.increment_counter(:failed_records, current_run.id)
       ImporterRun.find(current_run.id).decrement!(:enqueued_records) unless ImporterRun.find(current_run.id).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
     end
     # rubocop:enable Rails/SkipsModelValidations

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -271,7 +271,7 @@ module Bulkrax
       current_run.invalid_records += message
       current_run.save
       ImporterRun.increment_counter(:failed_records, current_run.id)
-      ImporterRun.find(current_run.id).decrement!(:enqueued_records) unless ImporterRun.find(current_run.id).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
+      ImporterRun.decrement_counter(:enqueued_records, current_run.id) unless ImporterRun.find(current_run.id).enqueued_records <= 0 # rubocop:disable Style/IdenticalConditionalBranches
     end
     # rubocop:enable Rails/SkipsModelValidations
 

--- a/spec/factories/bulkrax_exporter_runs.rb
+++ b/spec/factories/bulkrax_exporter_runs.rb
@@ -2,11 +2,11 @@
 
 FactoryBot.define do
   factory :bulkrax_exporter_run, class: 'Bulkrax::ExporterRun' do
-    exporter { nil }
+    exporter { FactoryBot.build(:bulkrax_exporter) }
     total_work_entries { 1 }
     enqueued_records { 1 }
-    processed_records { 1 }
-    deleted_records { 1 }
-    failed_records { 1 }
+    processed_records { 0 }
+    deleted_records { 0 }
+    failed_records { 0 }
   end
 end

--- a/spec/factories/bulkrax_importer_runs.rb
+++ b/spec/factories/bulkrax_importer_runs.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     importer { FactoryBot.build(:bulkrax_importer) }
     total_work_entries { 1 }
     enqueued_records { 1 }
-    processed_records { 1 }
-    deleted_records { 1 }
-    failed_records { 1 }
+    processed_records { 0 }
+    deleted_records { 0 }
+    failed_records { 0 }
   end
 end

--- a/spec/jobs/bulkrax/delete_work_job_spec.rb
+++ b/spec/jobs/bulkrax/delete_work_job_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 module Bulkrax
   RSpec.describe DeleteWorkJob, type: :job do
     subject(:delete_work_job) { described_class.new }
-    let(:entry) { FactoryBot.build(:bulkrax_entry) }
-    let(:importer_run) { FactoryBot.build(:bulkrax_importer_run) }
+    let(:entry) { create(:bulkrax_entry) }
+    let(:importer_run) { create(:bulkrax_importer_run) }
 
     describe 'successful job object removed' do
       before do
@@ -18,12 +18,14 @@ module Bulkrax
       end
 
       it 'increments :deleted_records' do
-        entry.save
-        importer_run.save
+        expect(importer_run.enqueued_records).to eq(1)
+        expect(importer_run.deleted_records).to eq(0)
+
         delete_work_job.perform(entry, importer_run)
         importer_run.reload
-        expect(importer_run.enqueued_records).to equal(0)
-        expect(importer_run.deleted_records).to equal(2)
+
+        expect(importer_run.enqueued_records).to eq(0)
+        expect(importer_run.deleted_records).to eq(1)
       end
     end
 
@@ -35,12 +37,14 @@ module Bulkrax
       end
 
       it 'increments :deleted_records' do
-        entry.save
-        importer_run.save
+        expect(importer_run.enqueued_records).to eq(1)
+        expect(importer_run.deleted_records).to eq(0)
+
         delete_work_job.perform(entry, importer_run)
         importer_run.reload
-        expect(importer_run.enqueued_records).to equal(0)
-        expect(importer_run.deleted_records).to equal(2)
+
+        expect(importer_run.enqueued_records).to eq(0)
+        expect(importer_run.deleted_records).to eq(1)
       end
     end
   end

--- a/spec/jobs/bulkrax/export_work_job_spec.rb
+++ b/spec/jobs/bulkrax/export_work_job_spec.rb
@@ -15,17 +15,33 @@ module Bulkrax
     end
 
     describe 'successful job' do
-      # TODO: split into specific changes
-      # TODO: cover all counters
-      it 'increments :processed_records and decrements enqueued record' do
+      it 'increments :processed_records' do
         expect(exporter_run.processed_records).to eq(0)
-        expect(exporter_run.enqueued_records).to eq(1)
 
         export_work_job.perform(entry.id, exporter_run.id)
         exporter_run.reload
 
         expect(exporter_run.processed_records).to eq(1)
+      end
+
+      it 'decrements :enqueued_records' do
+        expect(exporter_run.enqueued_records).to eq(1)
+
+        export_work_job.perform(entry.id, exporter_run.id)
+        exporter_run.reload
+
         expect(exporter_run.enqueued_records).to eq(0)
+      end
+
+      it "doesn't change unrelated counters" do
+        expect(exporter_run.failed_records).to eq(0)
+        expect(exporter_run.deleted_records).to eq(0)
+
+        export_work_job.perform(1, exporter_run.id)
+        exporter_run.reload
+
+        expect(exporter_run.failed_records).to eq(0)
+        expect(exporter_run.deleted_records).to eq(0)
       end
     end
   end

--- a/spec/jobs/bulkrax/export_work_job_spec.rb
+++ b/spec/jobs/bulkrax/export_work_job_spec.rb
@@ -5,23 +5,27 @@ require 'rails_helper'
 module Bulkrax
   RSpec.describe ExportWorkJob, type: :job do
     subject(:export_work_job) { described_class.new }
-    let(:entry) { FactoryBot.build(:bulkrax_entry) }
-    let(:exporter_run) { FactoryBot.build(:bulkrax_exporter_run) }
+    let(:exporter) { create(:bulkrax_exporter, :all) }
+    let(:entry) { create(:bulkrax_entry, importerexporter: exporter) }
+    let(:exporter_run) { create(:bulkrax_exporter_run, exporter: exporter) }
 
     before do
       allow(Bulkrax::Entry).to receive(:find).with(1).and_return(entry)
-      allow(Bulkrax::ExporterRun).to receive(:find).with(1).and_return(exporter_run)
       allow(entry).to receive(:build)
     end
 
     describe 'successful job' do
-      before do
-        allow(entry).to receive(:save).and_return(true)
-      end
+      # TODO: split into specific changes
+      # TODO: cover all counters
       it 'increments :processed_records and decrements enqueued record' do
-        expect(exporter_run).to receive(:increment!).with(:processed_records)
-        expect(exporter_run).to receive(:decrement!).with(:enqueued_records)
-        export_work_job.perform(1, 1)
+        expect(exporter_run.processed_records).to eq(0)
+        expect(exporter_run.enqueued_records).to eq(1)
+
+        export_work_job.perform(entry.id, exporter_run.id)
+        exporter_run.reload
+
+        expect(exporter_run.processed_records).to eq(1)
+        expect(exporter_run.enqueued_records).to eq(0)
       end
     end
   end

--- a/spec/jobs/bulkrax/import_file_set_job_spec.rb
+++ b/spec/jobs/bulkrax/import_file_set_job_spec.rb
@@ -16,7 +16,6 @@ module Bulkrax
 
     before do
       allow(Entry).to receive(:find).with(entry.id).and_return(entry)
-      allow(ImporterRun).to receive(:find).with(importer_run.id).and_return(importer_run)
       allow(::Hyrax.config).to receive(:curation_concerns).and_return([Work])
       allow(::Work).to receive(:where).and_return([])
       allow(importer.parser).to receive(:path_to_files).with(filename: 'removed.png').and_return('spec/fixtures/removed.png')
@@ -51,15 +50,23 @@ module Bulkrax
             import_file_set_job.perform(entry.id, importer_run.id)
           end
 
+          # TODO: split into specific changes
+          # TODO: cover all counters
           it "updates the importer run's counters" do
-            expect(importer_run).to receive(:increment!).with(:processed_records).once
-            expect(importer_run).to receive(:increment!).with(:processed_file_sets).once
-
-            expect(importer_run).not_to receive(:decrement!).with(:enqueued_records)
-            expect(importer_run).not_to receive(:increment!).with(:failed_records)
-            expect(importer_run).not_to receive(:increment!).with(:failed_file_sets)
+            expect(importer_run.processed_records).to eq(0)
+            expect(importer_run.processed_file_sets).to eq(0)
+            expect(importer_run.enqueued_records).to eq(0)
+            expect(importer_run.failed_records).to eq(0)
+            expect(importer_run.failed_file_sets).to eq(0)
 
             import_file_set_job.perform(entry.id, importer_run.id)
+            importer_run.reload
+
+            expect(importer_run.processed_records).to eq(1)
+            expect(importer_run.processed_file_sets).to eq(1)
+            expect(importer_run.enqueued_records).to eq(0)
+            expect(importer_run.failed_records).to eq(0)
+            expect(importer_run.failed_file_sets).to eq(0)
           end
         end
 
@@ -79,8 +86,8 @@ module Bulkrax
             end
 
             it "does not update any of importer run's counters" do
-              expect(importer_run).not_to receive(:increment!)
-              expect(importer_run).not_to receive(:decrement!)
+              expect(ImporterRun).not_to receive(:increment_counter)
+              expect(ImporterRun).not_to receive(:decrement_counter)
             end
 
             it 'reschedules the job to try again after a couple minutes' do
@@ -111,8 +118,11 @@ module Bulkrax
             end
 
             it "only decrements the importer run's :enqueued_records counter" do
-              expect(importer_run).not_to receive(:increment!)
-              expect(importer_run).to receive(:decrement!).with(:enqueued_records).once
+              expect(ImporterRun).not_to receive(:increment_counter)
+              expect(ImporterRun)
+                .to receive(:decrement_counter)
+                .with(:enqueued_records, importer_run.id)
+                .once
 
               import_file_set_job.perform(entry.id, importer_run.id)
             end
@@ -165,15 +175,23 @@ module Bulkrax
           import_file_set_job.perform(entry.id, importer_run.id)
         end
 
+        # TODO: split into specific changes
+        # TODO: cover all counters
         it "updates the importer run's counters" do
-          expect(importer_run).to receive(:increment!).with(:failed_records).once
-          expect(importer_run).to receive(:increment!).with(:failed_file_sets).once
-
-          expect(importer_run).not_to receive(:decrement!).with(:enqueued_records)
-          expect(importer_run).not_to receive(:increment!).with(:processed_records)
-          expect(importer_run).not_to receive(:increment!).with(:processed_file_sets)
+          expect(importer_run.failed_records).to eq(0)
+          expect(importer_run.failed_file_sets).to eq(0)
+          expect(importer_run.enqueued_records).to eq(0)
+          expect(importer_run.processed_records).to eq(0)
+          expect(importer_run.processed_file_sets).to eq(0)
 
           import_file_set_job.perform(entry.id, importer_run.id)
+          importer_run.reload
+
+          expect(importer_run.failed_records).to eq(1)
+          expect(importer_run.failed_file_sets).to eq(1)
+          expect(importer_run.enqueued_records).to eq(0)
+          expect(importer_run.processed_records).to eq(0)
+          expect(importer_run.processed_file_sets).to eq(0)
         end
       end
     end

--- a/spec/jobs/bulkrax/import_file_set_job_spec.rb
+++ b/spec/jobs/bulkrax/import_file_set_job_spec.rb
@@ -80,8 +80,6 @@ module Bulkrax
             expect(importer_run.failed_file_sets).to eq(0)
             expect(importer_run.processed_works).to eq(0)
             expect(importer_run.failed_works).to eq(0)
-            expect(importer_run.processed_children).to eq(0)
-            expect(importer_run.failed_children).to eq(0)
 
             import_file_set_job.perform(entry.id, importer_run.id)
             importer_run.reload
@@ -95,8 +93,6 @@ module Bulkrax
             expect(importer_run.failed_file_sets).to eq(0)
             expect(importer_run.processed_works).to eq(0)
             expect(importer_run.failed_works).to eq(0)
-            expect(importer_run.processed_children).to eq(0)
-            expect(importer_run.failed_children).to eq(0)
           end
         end
 
@@ -235,8 +231,6 @@ module Bulkrax
           expect(importer_run.processed_file_sets).to eq(0)
           expect(importer_run.processed_works).to eq(0)
           expect(importer_run.failed_works).to eq(0)
-          expect(importer_run.processed_children).to eq(0)
-          expect(importer_run.failed_children).to eq(0)
 
           import_file_set_job.perform(entry.id, importer_run.id)
           importer_run.reload
@@ -250,8 +244,6 @@ module Bulkrax
           expect(importer_run.processed_file_sets).to eq(0)
           expect(importer_run.processed_works).to eq(0)
           expect(importer_run.failed_works).to eq(0)
-          expect(importer_run.processed_children).to eq(0)
-          expect(importer_run.failed_children).to eq(0)
         end
       end
     end

--- a/spec/jobs/bulkrax/import_file_set_job_spec.rb
+++ b/spec/jobs/bulkrax/import_file_set_job_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 module Bulkrax
   RSpec.describe ImportFileSetJob, type: :job do
     subject(:import_file_set_job) { described_class.new }
-    let(:importer) { FactoryBot.create(:bulkrax_importer_csv_complex) }
-    let(:importer_run) { importer.current_run }
+    let(:importer) { create(:bulkrax_importer_csv_complex) }
+    let(:importer_run) { create(:bulkrax_importer_run, importer: importer) }
     let(:entry) { create(:bulkrax_csv_entry_file_set, :with_file_set_metadata, importerexporter: importer) }
     let(:factory) { instance_double(ObjectFactory) }
 
@@ -50,23 +50,53 @@ module Bulkrax
             import_file_set_job.perform(entry.id, importer_run.id)
           end
 
-          # TODO: split into specific changes
-          # TODO: cover all counters
-          it "updates the importer run's counters" do
+          it 'increments :processed_records and :processed_file_sets' do
             expect(importer_run.processed_records).to eq(0)
             expect(importer_run.processed_file_sets).to eq(0)
-            expect(importer_run.enqueued_records).to eq(0)
-            expect(importer_run.failed_records).to eq(0)
-            expect(importer_run.failed_file_sets).to eq(0)
 
             import_file_set_job.perform(entry.id, importer_run.id)
             importer_run.reload
 
             expect(importer_run.processed_records).to eq(1)
             expect(importer_run.processed_file_sets).to eq(1)
+          end
+
+          it 'decrements :enqueued_records' do
+            expect(importer_run.enqueued_records).to eq(1)
+
+            import_file_set_job.perform(entry.id, importer_run.id)
+            importer_run.reload
+
             expect(importer_run.enqueued_records).to eq(0)
+          end
+
+          it "doesn't change unrelated counters" do
             expect(importer_run.failed_records).to eq(0)
+            expect(importer_run.deleted_records).to eq(0)
+            expect(importer_run.processed_collections).to eq(0)
+            expect(importer_run.failed_collections).to eq(0)
+            expect(importer_run.processed_relationships).to eq(0)
+            expect(importer_run.failed_relationships).to eq(0)
             expect(importer_run.failed_file_sets).to eq(0)
+            expect(importer_run.processed_works).to eq(0)
+            expect(importer_run.failed_works).to eq(0)
+            expect(importer_run.processed_children).to eq(0)
+            expect(importer_run.failed_children).to eq(0)
+
+            import_file_set_job.perform(entry.id, importer_run.id)
+            importer_run.reload
+
+            expect(importer_run.failed_records).to eq(0)
+            expect(importer_run.deleted_records).to eq(0)
+            expect(importer_run.processed_collections).to eq(0)
+            expect(importer_run.failed_collections).to eq(0)
+            expect(importer_run.processed_relationships).to eq(0)
+            expect(importer_run.failed_relationships).to eq(0)
+            expect(importer_run.failed_file_sets).to eq(0)
+            expect(importer_run.processed_works).to eq(0)
+            expect(importer_run.failed_works).to eq(0)
+            expect(importer_run.processed_children).to eq(0)
+            expect(importer_run.failed_children).to eq(0)
           end
         end
 
@@ -175,23 +205,53 @@ module Bulkrax
           import_file_set_job.perform(entry.id, importer_run.id)
         end
 
-        # TODO: split into specific changes
-        # TODO: cover all counters
-        it "updates the importer run's counters" do
+        it 'increments :failed_records and :failed_file_sets' do
           expect(importer_run.failed_records).to eq(0)
           expect(importer_run.failed_file_sets).to eq(0)
-          expect(importer_run.enqueued_records).to eq(0)
-          expect(importer_run.processed_records).to eq(0)
-          expect(importer_run.processed_file_sets).to eq(0)
 
           import_file_set_job.perform(entry.id, importer_run.id)
           importer_run.reload
 
           expect(importer_run.failed_records).to eq(1)
           expect(importer_run.failed_file_sets).to eq(1)
+        end
+
+        it 'decrements :enqueued_records' do
+          expect(importer_run.enqueued_records).to eq(1)
+
+          import_file_set_job.perform(entry.id, importer_run.id)
+          importer_run.reload
+
           expect(importer_run.enqueued_records).to eq(0)
+        end
+
+        it "doesn't change unrelated counters" do
           expect(importer_run.processed_records).to eq(0)
+          expect(importer_run.deleted_records).to eq(0)
+          expect(importer_run.processed_collections).to eq(0)
+          expect(importer_run.failed_collections).to eq(0)
+          expect(importer_run.processed_relationships).to eq(0)
+          expect(importer_run.failed_relationships).to eq(0)
           expect(importer_run.processed_file_sets).to eq(0)
+          expect(importer_run.processed_works).to eq(0)
+          expect(importer_run.failed_works).to eq(0)
+          expect(importer_run.processed_children).to eq(0)
+          expect(importer_run.failed_children).to eq(0)
+
+          import_file_set_job.perform(entry.id, importer_run.id)
+          importer_run.reload
+
+          expect(importer_run.processed_records).to eq(0)
+          expect(importer_run.deleted_records).to eq(0)
+          expect(importer_run.processed_collections).to eq(0)
+          expect(importer_run.failed_collections).to eq(0)
+          expect(importer_run.processed_relationships).to eq(0)
+          expect(importer_run.failed_relationships).to eq(0)
+          expect(importer_run.processed_file_sets).to eq(0)
+          expect(importer_run.processed_works).to eq(0)
+          expect(importer_run.failed_works).to eq(0)
+          expect(importer_run.processed_children).to eq(0)
+          expect(importer_run.failed_children).to eq(0)
         end
       end
     end

--- a/spec/jobs/bulkrax/import_work_job_spec.rb
+++ b/spec/jobs/bulkrax/import_work_job_spec.rb
@@ -81,11 +81,22 @@ module Bulkrax
       before do
         allow(entry).to receive(:build_for_importer).and_raise(CollectionsCreatedError)
       end
-      it 'does not call increment' do
-        expect(importer_run).not_to receive(:increment!)
-        expect(importer_run).not_to receive(:decrement!)
+
+      it 'does not change counters' do
+        expect(importer_run.processed_records).to eq(0)
+        expect(importer_run.processed_works).to eq(0)
+        expect(importer_run.failed_records).to eq(0)
+        expect(importer_run.failed_works).to eq(0)
+
         import_work_job.perform(1, importer_run_id)
+        importer_run.reload
+
+        expect(importer_run.processed_records).to eq(0)
+        expect(importer_run.processed_works).to eq(0)
+        expect(importer_run.failed_records).to eq(0)
+        expect(importer_run.failed_works).to eq(0)
       end
+
       it 'reschedules the job' do
         expect(import_work_job).to receive(:reschedule) # rubocop:disable RSpec/SubjectStub
         import_work_job.perform(1, importer_run_id)
@@ -96,11 +107,25 @@ module Bulkrax
       before do
         allow(entry).to receive(:build).and_return(nil)
       end
-      it 'increments :failed_records' do
-        expect(importer_run).to receive(:increment!).with(:failed_records)
-        expect(importer_run).to receive(:increment!).with(:failed_works)
-        expect(importer_run).to receive(:decrement!).with(:enqueued_records)
+
+      it 'increments :failed_records and :failed_works' do
+        expect(importer_run.failed_records).to eq(0)
+        expect(importer_run.failed_works).to eq(0)
+
         import_work_job.perform(1, importer_run_id)
+        importer_run.reload
+
+        expect(importer_run.failed_records).to eq(1)
+        expect(importer_run.failed_works).to eq(1)
+      end
+
+      it 'decrements :enqueued_records' do
+        expect(importer_run.enqueued_records).to eq(1)
+
+        import_work_job.perform(1, importer_run_id)
+        importer_run.reload
+
+        expect(importer_run.enqueued_records).to eq(0)
       end
     end
 
@@ -108,10 +133,25 @@ module Bulkrax
       before do
         allow(entry).to receive(:build).and_raise(OAIError)
       end
-      it 'increments :failed_records' do
+
+      it 'does not increment :failed_records or :failed_works' do
+        expect(importer_run.failed_records).to eq(0)
+        expect(importer_run.failed_works).to eq(0)
+
         expect { import_work_job.perform(1, importer_run_id) }.to raise_error(OAIError)
-        expect(importer_run).not_to receive(:increment!).with(:failed_records)
-        expect(importer_run).not_to receive(:decrement!).with(:enqueued_records)
+        importer_run.reload
+
+        expect(importer_run.failed_records).to eq(0)
+        expect(importer_run.failed_works).to eq(0)
+      end
+
+      it 'does not decrement :enqueued_records' do
+        expect(importer_run.enqueued_records).to eq(1)
+
+        expect { import_work_job.perform(1, importer_run_id) }.to raise_error(OAIError)
+        importer_run.reload
+
+        expect(importer_run.enqueued_records).to eq(1)
       end
     end
   end

--- a/spec/jobs/bulkrax/import_work_job_spec.rb
+++ b/spec/jobs/bulkrax/import_work_job_spec.rb
@@ -11,7 +11,6 @@ module Bulkrax
 
     before do
       allow(Bulkrax::Entry).to receive(:find).with(1).and_return(entry)
-      allow(Bulkrax::ImporterRun).to receive(:find).with(importer_run_id).and_return(importer_run)
     end
 
     describe 'successful job' do
@@ -20,11 +19,61 @@ module Bulkrax
         allow(entry).to receive(:build).and_return(instance_of(Work))
         allow(entry).to receive(:status).and_return('Complete')
       end
+
       it 'increments :processed_records' do
-        expect(importer_run).to receive(:increment!).with(:processed_records)
-        expect(importer_run).to receive(:increment!).with(:processed_works)
-        expect(importer_run).to receive(:decrement!).with(:enqueued_records)
+        expect(importer_run.processed_records).to eq(0)
+
         import_work_job.perform(1, importer_run_id)
+        importer_run.reload
+
+        expect(importer_run.processed_records).to eq(1)
+      end
+
+      it 'increments :processed_works' do
+        expect(importer_run.processed_works).to eq(0)
+
+        import_work_job.perform(1, importer_run_id)
+        importer_run.reload
+
+        expect(importer_run.processed_works).to eq(1)
+      end
+
+      it 'decrements :enqueued_records' do
+        expect(importer_run.enqueued_records).to eq(1)
+
+        import_work_job.perform(1, importer_run_id)
+        importer_run.reload
+
+        expect(importer_run.enqueued_records).to eq(0)
+      end
+
+      it "doesn't change unrelated counters" do
+        expect(importer_run.failed_records).to eq(0)
+        expect(importer_run.deleted_records).to eq(0)
+        expect(importer_run.processed_collections).to eq(0)
+        expect(importer_run.failed_collections).to eq(0)
+        expect(importer_run.processed_relationships).to eq(0)
+        expect(importer_run.failed_relationships).to eq(0)
+        expect(importer_run.processed_file_sets).to eq(0)
+        expect(importer_run.failed_file_sets).to eq(0)
+        expect(importer_run.failed_works).to eq(0)
+        expect(importer_run.processed_children).to eq(0)
+        expect(importer_run.failed_children).to eq(0)
+
+        import_work_job.perform(1, importer_run_id)
+        importer_run.reload
+
+        expect(importer_run.failed_records).to eq(0)
+        expect(importer_run.deleted_records).to eq(0)
+        expect(importer_run.processed_collections).to eq(0)
+        expect(importer_run.failed_collections).to eq(0)
+        expect(importer_run.processed_relationships).to eq(0)
+        expect(importer_run.failed_relationships).to eq(0)
+        expect(importer_run.processed_file_sets).to eq(0)
+        expect(importer_run.failed_file_sets).to eq(0)
+        expect(importer_run.failed_works).to eq(0)
+        expect(importer_run.processed_children).to eq(0)
+        expect(importer_run.failed_children).to eq(0)
       end
     end
 

--- a/spec/jobs/bulkrax/import_work_job_spec.rb
+++ b/spec/jobs/bulkrax/import_work_job_spec.rb
@@ -57,8 +57,6 @@ module Bulkrax
         expect(importer_run.processed_file_sets).to eq(0)
         expect(importer_run.failed_file_sets).to eq(0)
         expect(importer_run.failed_works).to eq(0)
-        expect(importer_run.processed_children).to eq(0)
-        expect(importer_run.failed_children).to eq(0)
 
         import_work_job.perform(1, importer_run_id)
         importer_run.reload
@@ -72,8 +70,6 @@ module Bulkrax
         expect(importer_run.processed_file_sets).to eq(0)
         expect(importer_run.failed_file_sets).to eq(0)
         expect(importer_run.failed_works).to eq(0)
-        expect(importer_run.processed_children).to eq(0)
-        expect(importer_run.failed_children).to eq(0)
       end
     end
 

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -99,8 +99,6 @@ ActiveRecord::Schema.define(version: 2023_06_08_153601) do
     t.integer "total_file_set_entries", default: 0
     t.integer "processed_works", default: 0
     t.integer "failed_works", default: 0
-    t.integer "processed_children", default: 0
-    t.integer "failed_children", default: 0
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 


### PR DESCRIPTION
# Story

SQL logs before changes (using `#increment!`):

```sql
Bulkrax::ImporterRun Load (8.9ms)  SELECT  "bulkrax_importer_runs".* FROM "bulkrax_importer_runs" WHERE "bulkrax_importer_runs"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
Bulkrax::ImporterRun Update All (2.5ms)  UPDATE "bulkrax_importer_runs" SET "processed_records" = COALESCE("processed_records", 0) + 1 WHERE "bulkrax_importer_runs"."id" = $1  [["id", 1]]
```

SQL logs after changes (using `#increment_counter`):

```sql
Bulkrax::ImporterRun Update All (6.5ms)  UPDATE "bulkrax_importer_runs" SET "processed_records" = COALESCE("processed_records", 0) + 1 WHERE "bulkrax_importer_runs"."id" = $1  [["id", 1]]
```

The `SELECT` statement serves no purpose since the `UPDATE` statement is atomic.

I haven't done any benchmarks on these changes, but since less SQL statements seems like a pretty obvious win and since we update counters _a ton_, I'm hoping we'll see at least some speed improvements 