### PR TITLE
unpin dry-monads. its not a dependency of bulkrax

### DIFF
--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 5.1.6'
   s.add_dependency 'bagit', '~> 0.4'
   s.add_dependency 'coderay'
-  s.add_dependency 'dry-monads', '~> 1.5.0'
   s.add_dependency 'iso8601', '~> 0.9.0'
   s.add_dependency 'kaminari'
   s.add_dependency 'language_list', '~> 1.2', '>= 1.2.1'


### PR DESCRIPTION
This was previously pinned to make specs green. probably should have been in the gemfile instead