### PR TITLE
🎁 Add `Bulkrax.persistence_adapter`

### DIFF
--- a/lib/bulkrax/engine.rb
+++ b/lib/bulkrax/engine.rb
@@ -13,6 +13,12 @@ module Bulkrax
       end
     end
 
+    initializer 'requires' do
+      require 'bulkrax/persistence_layer'
+      require 'bulkrax/persistence_layer/active_fedora_adapter' if defined?(ActiveFedora)
+      require 'bulkrax/persistence_layer/valkyrie_adapter' if defined?(Valkyrie)
+    end
+
     config.generators do |g|
       g.test_framework :rspec
       begin

--- a/lib/bulkrax/persistence_layer.rb
+++ b/lib/bulkrax/persistence_layer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  ##
+  # The target data layer where we write and read our imported {Bulkrax::Entry} objects.
+  module PersistenceLayer
+    # We're inheriting from an ActiveRecord exception as that is something we know will be here; and
+    # something that the main_app will be expect to be able to handle.
+    class ObjectNotFoundError < ActiveRecord::RecordNotFound
+    end
+
+    # We're inheriting from an ActiveRecord exception as that is something we know will be here; and
+    # something that the main_app will be expect to be able to handle.
+    class RecordInvalid < ActiveRecord::RecordInvalid
+    end
+
+    class AbstractAdapter
+      # @see ActiveFedora::Base.find
+      def self.find(id)
+        raise NotImplementedError, "#{self}.#{__method__}"
+      end
+
+      def self.solr_name(field_name)
+        raise NotImplementedError, "#{self}.#{__method__}"
+      end
+
+      # @yield when Rails application is running in test environment.
+      def self.clean!
+        return true unless Rails.env.test?
+        yield
+      end
+
+      def self.query(q, **kwargs)
+        raise NotImplementedError, "#{self}.#{__method__}"
+      end
+    end
+  end
+end

--- a/lib/bulkrax/persistence_layer/active_fedora_adapter.rb
+++ b/lib/bulkrax/persistence_layer/active_fedora_adapter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  module PersistenceLayer
+    class ActiveFedoraAdapter < AbstractAdapter
+      def self.find(id)
+        ActiveFedora::Base.find(id)
+      rescue ActiveFedora::ObjectNotFoundError => e
+        raise PersistenceLayer::RecordNotFound, e.message
+      end
+
+      def self.query(q, **kwargs)
+        ActiveFedora::SolrService.query(q, **kwargs)
+      end
+
+      def self.clean!
+        super do
+          ActiveFedora::Cleaner.clean!
+        end
+      end
+
+      def self.solr_name(field_name)
+        ActiveFedora.index_field_mapper.solr_name(field_name)
+      end
+    end
+  end
+end

--- a/lib/bulkrax/persistence_layer/valkyrie_adapter.rb
+++ b/lib/bulkrax/persistence_layer/valkyrie_adapter.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Bulkrax
+  module PersistenceLayer
+    class ValkyrieAdapter < AbstractAdapter
+    end
+  end
+end

--- a/spec/lib/bulkrax_spec.rb
+++ b/spec/lib/bulkrax_spec.rb
@@ -197,4 +197,12 @@ RSpec.describe Bulkrax do
       expect(returned_value).to eq("file")
     end
   end
+
+  context '.persistence_adapter' do
+    subject { described_class.persistence_adapter }
+    it { is_expected.to respond_to(:find) }
+    it { is_expected.to respond_to(:query) }
+    it { is_expected.to respond_to(:solr_name) }
+    it { is_expected.to respond_to(:clean!) }
+  end
 end


### PR DESCRIPTION
# 🎁 Add `Bulkrax.persistence_adapter`

At present we have not incorporated using the
`Bulkrax.persistence_adapter` into the application.  It is instead put
forward for discussion and review.
    
Why introduce the adapter strategy?  Because there are several instances
of Bulkrax that are installed along various points of Hyrax
versions as well as non-Hyrax versions; which means that there are some
cases where we'll be using ActiveFedora and some where we'll be moving
towards Valkyrie.
    
The goal of the adapter is two fold:
    
- Clarify and define the data interface between Bulkrax and the Main App
- Allow for ease of maintaining Bulkrax releative to varying versions of
  Hyrax and Hyku; thus allowing folks to upgrade to new features of
  Bulkrax without mandating an upgrade of their entire persistence
  strategy.
    
Related to:
    
- https://github.com/scientist-softserv/hykuup_knapsack/issues/35
