### PR TITLE
🎁 Config option for coercing a factory class name

### DIFF
--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -44,6 +44,25 @@ module Bulkrax
     attr_writer :persistence_adapter
 
     ##
+    # @param coercer [#call]
+    # @see Bulkrax::FactoryClassFinder
+    attr_writer :factory_class_name_coercer
+
+    ##
+    # A function responsible for converting the name of a factory class to the corresponding
+    # constant.
+    #
+    # @return [#call, Bulkrax::FactoryClassFinder::DefaultCoercer] an object responding to call,
+    #         with one positional parameter (e.g. arity == 1)
+    #
+    # @example
+    #   Bulkrax.factory_class_name_coercer.call("Work")
+    #   => Work
+    def factory_class_name_coercer
+      @factory_class_name_coercer || Bulkrax::FactoryClassFinder::DefaultCoercer
+    end
+
+    ##
     # Configure the persistence adapter used for persisting imported data.
     #
     # @return [Class<Bulkrax::PersistenceLayer::AbstractAdapter>]
@@ -99,6 +118,8 @@ module Bulkrax
                  :default_work_type=,
                  :export_path,
                  :export_path=,
+                 :factory_class_name_coercer,
+                 :factory_class_name_coercer=,
                  :field_mappings,
                  :field_mappings=,
                  :file_model_class,

--- a/spec/lib/bulkrax_spec.rb
+++ b/spec/lib/bulkrax_spec.rb
@@ -205,4 +205,14 @@ RSpec.describe Bulkrax do
     it { is_expected.to respond_to(:solr_name) }
     it { is_expected.to respond_to(:clean!) }
   end
+
+  context '.factory_class_name_coercer' do
+    subject { described_class.factory_class_name_coercer }
+
+    it { is_expected.to respond_to(:call) }
+
+    it "has a method arity of 1" do
+      expect(subject.method(:call).arity).to eq 1
+    end
+  end
 end

--- a/spec/services/bulkrax/factory_class_finder_spec.rb
+++ b/spec/services/bulkrax/factory_class_finder_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::FactoryClassFinder do
+  let(:legacy_work_class) { Class.new }
+  let(:legacy_work_resource_class) { Class.new }
+  let(:valkyrie_only_resource_class) { Class.new }
+  let(:active_fedora_only_class) { Class.new }
+
+  before do
+    Object.const_set(:LegacyWork, legacy_work_class)
+    Object.const_set(:LegacyWorkResource, legacy_work_resource_class)
+    Object.const_set(:ValkyrieOnlyResource, valkyrie_only_resource_class)
+    Object.const_set(:ActiveFedoraOnly, active_fedora_only_class)
+  end
+
+  after do
+    Object.send(:remove_const, :LegacyWork)
+    Object.send(:remove_const, :LegacyWorkResource)
+    Object.send(:remove_const, :ValkyrieOnlyResource)
+    Object.send(:remove_const, :ActiveFedoraOnly)
+  end
+
+  describe "DefaultCoercer" do
+    it "simply constantizes (unsafely) the given string" do
+      factory_class_name = "Work"
+      expect(described_class::DefaultCoercer.call(factory_class_name)).to eq(Work)
+    end
+  end
+
+  describe "ValkyrieMigrationCoercer" do
+    it 'favors mapping names to those ending in Resource' do
+      expect(described_class::ValkyrieMigrationCoercer.call("LegacyWork")).to eq(legacy_work_resource_class)
+      expect(described_class::ValkyrieMigrationCoercer.call("LegacyWorkResource")).to eq(legacy_work_resource_class)
+      expect(described_class::ValkyrieMigrationCoercer.call("ValkyrieOnlyResource")).to eq(valkyrie_only_resource_class)
+      expect(described_class::ValkyrieMigrationCoercer.call("ValkyrieOnly")).to eq(valkyrie_only_resource_class)
+      expect(described_class::ValkyrieMigrationCoercer.call("ActiveFedoraOnly")).to eq(active_fedora_only_class)
+      expect { described_class::ValkyrieMigrationCoercer.call("ActiveFedoraOnlyResource") }.to raise_error(NameError)
+    end
+  end
+
+  describe '.find' do
+    let(:entry) { double(Bulkrax::Entry, parsed_metadata: { "model" => model_name }, default_work_type: "Work") }
+    subject(:finder) { described_class.find(entry: entry, coercer: coercer) }
+
+    [
+      [Bulkrax::FactoryClassFinder::DefaultCoercer, "Legacy Work", "LegacyWork"],
+      [Bulkrax::FactoryClassFinder::ValkyrieMigrationCoercer, "Legacy Work", "LegacyWorkResource"],
+      [Bulkrax::FactoryClassFinder::DefaultCoercer, "Legacy Work Resource", "LegacyWorkResource"]
+    ].each do |given_coercer, given_model_name, expected_class_name|
+      context "with an entry with model: #{given_model_name} and coercer: #{given_coercer}" do
+        let(:model_name) { given_model_name }
+        let(:coercer) { given_coercer }
+
+        it { is_expected.to eq expected_class_name.constantize }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, once we had a factory class name we always called `#constantize` on the string.

With this commit, we retain that default behavior by:

1. Introducing a function that does this thing
2. Exposing a configuration end-point for that function

Further, we add a looming Valkyrie convention; namely that for each legacy named model (e.g. `Work`) there will likely be a corresponding model with the Resrouce suffix (e.g. `WorkResource`).

Related to:

- https://github.com/scientist-softserv/hykuup_knapsack/issues/125