### PR TITLE
i903 - move bulkrax identifier custom queries into bulkrax

### DIFF
--- a/app/services/bulkrax/valkyrie/find_by_bulkrax_identifier.rb
+++ b/app/services/bulkrax/valkyrie/find_by_bulkrax_identifier.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Bulkrax
+  module Valkyrie
+    module CustomQueries
+      ##
+      # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
+      class FindByBulkraxIdentifier
+        def self.queries
+          [:find_by_bulkrax_identifier]
+        end
+
+        def initialize(query_service:)
+          @query_service = query_service
+        end
+
+        attr_reader :query_service
+        delegate :resource_factory, to: :query_service
+        delegate :orm_class, to: :resource_factory
+
+        ##
+        # @param identifier String
+        def find_by_bulkrax_identifier(identifier:)
+          query_service.run_query(sql_by_bulkrax_identifier, identifier).first
+        end
+
+        def sql_by_bulkrax_identifier
+          <<-SQL
+            SELECT * FROM orm_resources
+            WHERE metadata -> 'bulkrax_identifier' ->> 0 = ?;
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/app/services/wings/custom_queries/find_by_bulkrax_identifier.rb
+++ b/app/services/wings/custom_queries/find_by_bulkrax_identifier.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Wings
+  module CustomQueries
+    class FindByBulkraxIdentifier
+      # Custom query override specific to Wings
+      # Use:
+      #   Hyrax.custom_queries.find_bulkrax_id(identifier: identifier, models: [ModelClass])
+
+      def self.queries
+        [:find_by_bulkrax_identifier]
+      end
+
+      attr_reader :query_service
+      delegate :resource_factory, to: :query_service
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      def find_by_bulkrax_identifier(identifier:, use_valkyrie: true)
+        af_object = ActiveFedora::Base.where("bulkrax_identifier_sim:#{identifier}").first
+
+        return af_object unless use_valkyrie
+
+        resource_factory.to_resource(object: af_object)
+      end
+    end
+  end
+end


### PR DESCRIPTION
move bulkrax identifier custom queries into bulkrax. Support for hyrax/valkyrized applications that use bulkrax_identifier.  ref: [GBH](https://github.com/search?q=repo%3AWGBH-MLA%2Fams%20bulkrax_identifier&type=code)

Issue:
- https://github.com/scientist-softserv/hykuup_knapsack/issues/136

Related: 
- https://github.com/samvera/bulkrax/pull/905