### PR TITLE
♻️ Favor Bulkrax's persistence layer

### DIFF
--- a/app/models/concerns/bulkrax/dynamic_record_lookup.rb
+++ b/app/models/concerns/bulkrax/dynamic_record_lookup.rb
@@ -18,7 +18,7 @@ module Bulkrax
       begin
         # the identifier parameter can be a :source_identifier or the id of an object
         record = Entry.find_by(default_scope.merge({ importerexporter_id: importer_id })) || Entry.find_by(default_scope)
-        record ||= ActiveFedora::Base.find(identifier)
+        record ||= Bulkrax.persistence_adapter.find(identifier)
       # NameError for if ActiveFedora isn't installed
       rescue NameError, ActiveFedora::ObjectNotFoundError
         record = nil

--- a/app/models/concerns/bulkrax/export_behavior.rb
+++ b/app/models/concerns/bulkrax/export_behavior.rb
@@ -22,7 +22,7 @@ module Bulkrax
     end
 
     def hyrax_record
-      @hyrax_record ||= ActiveFedora::Base.find(self.identifier)
+      @hyrax_record ||= Bulkrax.persistence_adapter.find(self.identifier)
     end
 
     # Prepend the file_set id to ensure a unique filename and also one that is not longer than 255 characters

--- a/app/parsers/bulkrax/bagit_parser.rb
+++ b/app/parsers/bulkrax/bagit_parser.rb
@@ -100,7 +100,7 @@ module Bulkrax
       file_set_entries = importerexporter.entries.where(type: file_set_entry_class.to_s)
 
       work_entries[0..limit || total].each do |entry|
-        record = ActiveFedora::Base.find(entry.identifier)
+        record = Bulkrax.persistence_adapter.find(entry.identifier)
         next unless record
 
         bag_entries = [entry]

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -286,7 +286,7 @@ module Bulkrax
     end
 
     def store_files(identifier, folder_count)
-      record = ActiveFedora::Base.find(identifier)
+      record = Bulkrax.persistence_adapter.find(identifier)
       return unless record
 
       file_sets = record.file_set? ? Array.wrap(record) : record.file_sets

--- a/app/parsers/bulkrax/parser_export_record_set.rb
+++ b/app/parsers/bulkrax/parser_export_record_set.rb
@@ -149,12 +149,12 @@ module Bulkrax
       end
 
       def works
-        @works ||= ActiveFedora::SolrService.query(works_query, **works_query_kwargs)
+        @works ||= Bulkrax.persistence_adapter.query(works_query, **works_query_kwargs)
       end
 
       def collections
         @collections ||= if collections_query
-                           ActiveFedora::SolrService.query(collections_query, **collections_query_kwargs)
+                           Bulkrax.persistence_adapter.query(collections_query, **collections_query_kwargs)
                          else
                            []
                          end
@@ -175,7 +175,7 @@ module Bulkrax
         @file_sets ||= ParserExportRecordSet.in_batches(candidate_file_set_ids) do |batch_of_ids|
           fsq = "has_model_ssim:#{Bulkrax.file_model_class} AND id:(\"" + batch_of_ids.join('" OR "') + "\")"
           fsq += extra_filters if extra_filters.present?
-          ActiveFedora::SolrService.query(
+          Bulkrax.persistence_adapter.query(
             fsq,
             { fl: "id", method: :post, rows: batch_of_ids.size }
           )
@@ -247,7 +247,7 @@ module Bulkrax
 
       def works
         @works ||= ParserExportRecordSet.in_batches(complete_entry_identifiers) do |ids|
-          ActiveFedora::SolrService.query(
+          Bulkrax.persistence_adapter.query(
             extra_filters.to_s,
             **query_kwargs.merge(
               fq: [
@@ -262,7 +262,7 @@ module Bulkrax
 
       def collections
         @collections ||= ParserExportRecordSet.in_batches(complete_entry_identifiers) do |ids|
-          ActiveFedora::SolrService.query(
+          Bulkrax.persistence_adapter.query(
             "has_model_ssim:Collection #{extra_filters}",
             **query_kwargs.merge(
               fq: [
@@ -281,7 +281,7 @@ module Bulkrax
       # @see Bulkrax::ParserExportRecordSet::Base#file_sets
       def file_sets
         @file_sets ||= ParserExportRecordSet.in_batches(complete_entry_identifiers) do |ids|
-          ActiveFedora::SolrService.query(
+          Bulkrax.persistence_adapter.query(
             extra_filters,
             query_kwargs.merge(
               fq: [

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -288,7 +288,7 @@ module Bulkrax
         let(:fileset_entry_2) { FactoryBot.create(:bulkrax_csv_entry_file_set, importerexporter: exporter) }
 
         before do
-          allow(ActiveFedora::SolrService).to receive(:query).and_return(work_ids_solr)
+          allow(Bulkrax.persistence_adapter).to receive(:query).and_return(work_ids_solr)
           allow(exporter.entries).to receive(:where).and_return([work_entry_1, work_entry_2, fileset_entry_1, fileset_entry_2])
         end
 

--- a/spec/parsers/bulkrax/bagit_parser_spec.rb
+++ b/spec/parsers/bulkrax/bagit_parser_spec.rb
@@ -293,7 +293,7 @@ module Bulkrax
         end
 
         it 'attempts to find the related record' do
-          expect(ActiveFedora::Base).to receive(:find).with('csv_entry').and_return(nil)
+          expect(Bulkrax.persistence_adapter).to receive(:find).with('csv_entry').and_return(nil)
 
           subject.write_files
         end

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -633,7 +633,7 @@ module Bulkrax
       end
 
       before do
-        allow(ActiveFedora::SolrService).to receive(:query).and_return(SolrDocument.new(id: work_id))
+        allow(Bulkrax.persistence_adapter).to receive(:query).and_return(SolrDocument.new(id: work_id))
         allow(exporter.entries).to receive(:where).and_return([entry])
         allow(parser).to receive(:headers).and_return(entry.parsed_metadata.keys)
       end

--- a/spec/support/dynamic_record_lookup.rb
+++ b/spec/support/dynamic_record_lookup.rb
@@ -10,7 +10,7 @@ module Bulkrax
       allow(::Hyrax.config).to receive(:curation_concerns).and_return([Work])
       # DRY spec setup -- by default, assume #find_record doesn't find anything
       allow(Entry).to receive(:find_by).and_return(nil)
-      allow(ActiveFedora::Base).to receive(:find).and_return(nil)
+      allow(Bulkrax.persistence_adapter).to receive(:find).and_return(nil)
     end
 
     describe '#find_record' do
@@ -19,7 +19,7 @@ module Bulkrax
 
         it 'looks through entries and all work types' do
           expect(Entry).to receive(:find_by).with({ identifier: source_identifier, importerexporter_type: 'Bulkrax::Importer', importerexporter_id: importer_id }).once
-          expect(ActiveFedora::Base).to receive(:find).with(source_identifier).once.and_return(ActiveFedora::ObjectNotFoundError)
+          expect(Bulkrax.persistence_adapter).to receive(:find).with(source_identifier).once.and_return(ActiveFedora::ObjectNotFoundError)
 
           subject.find_record(source_identifier, importer_run_id)
         end
@@ -61,7 +61,7 @@ module Bulkrax
 
         it 'looks through entries and all work types' do
           expect(Entry).to receive(:find_by).with({ identifier: id, importerexporter_type: 'Bulkrax::Importer', importerexporter_id: importer_id }).once
-          expect(ActiveFedora::Base).to receive(:find).with(id).once.and_return(nil)
+          expect(Bulkrax.persistence_adapter).to receive(:find).with(id).once.and_return(nil)
 
           subject.find_record(id, importer_run_id)
         end
@@ -70,7 +70,7 @@ module Bulkrax
           let(:collection) { instance_double(::Collection) }
 
           before do
-            allow(ActiveFedora::Base).to receive(:find).with(id).and_return(collection)
+            allow(Bulkrax.persistence_adapter).to receive(:find).with(id).and_return(collection)
           end
 
           it 'returns the collection' do
@@ -82,7 +82,7 @@ module Bulkrax
           let(:work) { instance_double(::Work) }
 
           before do
-            allow(ActiveFedora::Base).to receive(:find).with(id).and_return(work)
+            allow(Bulkrax.persistence_adapter).to receive(:find).with(id).and_return(work)
           end
 
           it 'returns the work' do


### PR DESCRIPTION
Instead of direct calls to a deprecated service favor a persistence layer call; one that defines an interface.

Note this means we need to implement the methods in the Valkyrie adapter; but those should be trivial.