### PR TITLE
⚙️ Adding dry-monads as development dependency

### DIFF
--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rubyzip'
   s.add_dependency 'simple_form'
 
+  s.add_development_dependency 'dry-monads'
   s.add_development_dependency 'sqlite3', '~> 1.3.13'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'redis', '~> 4.2'


### PR DESCRIPTION
Without the previously committed `require 'dry-monads'` we encounter the following error:

```
bundle exec rspec

NameError:
  uninitialized constant Dry::Monads::Result::Transformer
 ./spec/test_app/config/application.rb:15:in `<top (required)>'
 ./spec/test_app/config/environment.rb:4:in `require_relative'
 ./spec/test_app/config/environment.rb:4:in `<top (required)>'
 ./spec/rails_helper.rb:8:in `<top (required)>'
 ./spec/parsers/bulkrax/xml_parser_spec.rb:3:in `<top (required)>'
```

The error repeats everywhere.

When I add the development dependency and remove the require, I see the same error.

So, to be clear about this development dependency, I've added it to the gemspec.

See:

- https://github.com/samvera/bulkrax/pull/900#discussion_r1480995354
- https://github.com/samvera/bulkrax/pull/900