### PR TITLE
🧹 Make DeleteJob work wth new class method .find

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -189,6 +189,10 @@ module Bulkrax
       Rails.logger.info("#{msg} (#{Array(attributes[work_identifier]).first})")
     end
 
+    def delete(obj, _user)
+      obj&.delete
+    end
+
     private
 
     # @param [Hash] attrs the attributes to put in the environment

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -122,7 +122,8 @@ module Bulkrax
     def find
       found = find_by_id if attributes[:id].present?
       return found if found.present?
-      return search_by_identifier if attributes[work_identifier].present?
+      return search_by_identifier if source_identifier_value.present?
+
       false
     end
 
@@ -189,8 +190,8 @@ module Bulkrax
       Rails.logger.info("#{msg} (#{Array(attributes[work_identifier]).first})")
     end
 
-    def delete(obj, _user)
-      obj&.delete
+    def delete(_user)
+      find&.delete
     end
 
     private

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -195,6 +195,12 @@ module Bulkrax
       @object.thumbnail_id = nil
     end
 
+    def delete(obj, user)
+      Hyrax.persister.delete(resource: obj)
+      Hyrax.index_adapter.delete(resource: obj)
+      Hyrax.publisher.publish('object.deleted', object: obj, user: user)
+    end
+
     private
 
     # TODO: Rename to transaction_create

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -195,7 +195,10 @@ module Bulkrax
       @object.thumbnail_id = nil
     end
 
-    def delete(obj, user)
+    def delete(user)
+      obj = find
+      return false unless obj
+
       Hyrax.persister.delete(resource: obj)
       Hyrax.index_adapter.delete(resource: obj)
       Hyrax.publisher.publish('object.deleted', object: obj, user: user)

--- a/app/jobs/bulkrax/delete_job.rb
+++ b/app/jobs/bulkrax/delete_job.rb
@@ -5,9 +5,8 @@ module Bulkrax
     queue_as :import
 
     def perform(entry, importer_run)
-      obj = entry.factory.class.find(entry.raw_metadata["id"])
       user = importer_run.importer.user
-      entry.factory.delete(obj, user)
+      entry.factory.delete(user)
 
       # rubocop:disable Rails/SkipsModelValidations
       ImporterRun.increment_counter(:deleted_records, importer_run.id)

--- a/app/jobs/bulkrax/delete_job.rb
+++ b/app/jobs/bulkrax/delete_job.rb
@@ -6,14 +6,8 @@ module Bulkrax
 
     def perform(entry, importer_run)
       obj = entry.factory.class.find(entry.raw_metadata["id"])
-
-      if defined?(Valkyrie) && obj.class < Valkyrie::Resource
-        Hyrax.persister.delete(resource: obj)
-        Hyrax.index_adapter.delete(resource: obj)
-        Hyrax.publisher.publish('object.deleted', object: obj, user: importer_run.importer.user)
-      else
-        obj&.delete
-      end
+      user = importer_run.importer.user
+      entry.factory.delete(obj, user)
 
       # rubocop:disable Rails/SkipsModelValidations
       ImporterRun.increment_counter(:deleted_records, importer_run.id)

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -311,6 +311,9 @@ module Bulkrax
         identifier: identifier
       ).first_or_create!
       entry.raw_metadata = raw_metadata
+      # Setting parsed_metadata specifically for the id so we can find the object via the
+      # id in a delete.  This is likely to get clobbered in a regular import, which is fine.
+      entry.parsed_metadata = { id: raw_metadata['id'] } if raw_metadata&.key?('id')
       entry.save!
       entry
     end

--- a/spec/jobs/bulkrax/delete_work_job_spec.rb
+++ b/spec/jobs/bulkrax/delete_work_job_spec.rb
@@ -7,14 +7,19 @@ module Bulkrax
     subject(:delete_work_job) { described_class.new }
     let(:entry) { create(:bulkrax_entry) }
     let(:importer_run) { create(:bulkrax_importer_run) }
+    let(:factory) do
+      Bulkrax::ObjectFactory.new(attributes: {},
+                                 source_identifier_value: '123',
+                                 work_identifier: :source,
+                                 work_identifier_search_field: :source_identifier)
+    end
 
     describe 'successful job object removed' do
       before do
         work = instance_double("Work")
-        factory = instance_double("Bulkrax::ObjectFactory")
-        expect(work).to receive(:delete).and_return true
-        expect(factory).to receive(:find).and_return(work)
-        expect(entry).to receive(:factory).and_return(factory)
+        allow(work).to receive(:delete).and_return true
+        allow(factory.class).to receive(:find).and_return(work)
+        allow(entry).to receive(:factory).and_return(factory)
       end
 
       it 'increments :deleted_records' do
@@ -31,9 +36,8 @@ module Bulkrax
 
     describe 'successful job object not found' do
       before do
-        factory = instance_double("Bulkrax::ObjectFactory")
-        expect(factory).to receive(:find).and_return(nil)
-        expect(entry).to receive(:factory).and_return(factory)
+        allow(factory.class).to receive(:find).and_return(nil)
+        allow(entry).to receive(:factory).and_return(factory)
       end
 
       it 'increments :deleted_records' do

--- a/spec/jobs/bulkrax/delete_work_job_spec.rb
+++ b/spec/jobs/bulkrax/delete_work_job_spec.rb
@@ -18,7 +18,7 @@ module Bulkrax
       before do
         work = instance_double("Work")
         allow(work).to receive(:delete).and_return true
-        allow(factory.class).to receive(:find).and_return(work)
+        allow(factory).to receive(:find).and_return(work)
         allow(entry).to receive(:factory).and_return(factory)
       end
 
@@ -36,7 +36,7 @@ module Bulkrax
 
     describe 'successful job object not found' do
       before do
-        allow(factory.class).to receive(:find).and_return(nil)
+        allow(factory).to receive(:find).and_return(nil)
         allow(entry).to receive(:factory).and_return(factory)
       end
 


### PR DESCRIPTION
The DeleteJob previously was not working with the old factory#find method because when it is doing a delete action, the parsed_metadata does not get generated like during a regular import.  Because of this, the #search_by_identifier method fails to find anything because we don't have a `work_identifier` field which would have came from the parsed_metadata.  So instead, we are using the new class method .find which will take an id (which we find on the raw_metadata) to find the object.  We make sure to reindex and publish the action to any relevant listeners.