### PR TITLE
Denormalize Status Message to that Entry Look Up Can Be Fast

### DIFF
--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -123,14 +123,14 @@ module Bulkrax
       @last_run ||= self.importer_runs.last
     end
 
+    def has_failed_entries?
+      entries.failed.any?
+    end
+
     def failed_statuses
       @failed_statuses ||= Bulkrax::Status.latest_by_statusable
                                           .includes(:statusable)
                                           .where('bulkrax_statuses.statusable_id IN (?) AND bulkrax_statuses.statusable_type = ? AND status_message = ?', self.entries.pluck(:id), 'Bulkrax::Entry', 'Failed')
-    end
-
-    def failed_entries
-      @failed_entries ||= failed_statuses.map(&:statusable)
     end
 
     def failed_messages
@@ -144,10 +144,6 @@ module Bulkrax
       @completed_statuses ||= Bulkrax::Status.latest_by_statusable
                                              .includes(:statusable)
                                              .where('bulkrax_statuses.statusable_id IN (?) AND bulkrax_statuses.statusable_type = ? AND status_message = ?', self.entries.pluck(:id), 'Bulkrax::Entry', 'Complete')
-    end
-
-    def completed_entries
-      @completed_entries ||= completed_statuses.map(&:statusable)
     end
 
     def seen

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -123,7 +123,7 @@ module Bulkrax
       @last_run ||= self.importer_runs.last
     end
 
-    def has_failed_entries?
+    def failed_entries?
       entries.failed.any?
     end
 

--- a/app/models/bulkrax/status.rb
+++ b/app/models/bulkrax/status.rb
@@ -23,7 +23,7 @@ module Bulkrax
     end
 
     def latest?
-      self.id == self.class.where(statusable_id: self.statusable_id, statusable_type: self.statusable_type).order('id desc').pluck(:id).first
+      self.id == self.class.where(statusable_id: self.statusable_id, statusable_type: self.statusable_type).order('id desc').pick(:id)
     end
   end
 end

--- a/app/models/concerns/bulkrax/status_info.rb
+++ b/app/models/concerns/bulkrax/status_info.rb
@@ -10,6 +10,9 @@ module Bulkrax
               as: :statusable,
               class_name: "Bulkrax::Status",
               inverse_of: :statusable
+      scope :failed, -> { where(status_message: 'Failed') }
+      scope :complete, -> { where(status_message: 'Complete') }
+      scope :pending, -> { where(status_message: 'Pending') }
     end
 
     def current_status

--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 5.1.6'
   s.add_dependency 'bagit', '~> 0.4'
   s.add_dependency 'coderay'
+  s.add_dependency 'denormalize_fields'
   s.add_dependency 'iso8601', '~> 0.9.0'
   s.add_dependency 'kaminari'
   s.add_dependency 'language_list', '~> 1.2', '>= 1.2.1'

--- a/db/migrate/20240208005801_denormalize_status_message.rb
+++ b/db/migrate/20240208005801_denormalize_status_message.rb
@@ -1,7 +1,7 @@
 class DenormalizeStatusMessage < ActiveRecord::Migration[5.2]
   def change
-    add_column :bulkrax_entries, :status_message, :string, default: 'Pending'
-    add_column :bulkrax_importers, :status_message, :string, default: 'Pending'
-    add_column :bulkrax_exporters, :status_message, :string, default: 'Pending'
+    add_column :bulkrax_entries, :status_message, :string, default: 'Pending' unless column_exists?(:bulkrax_entries, :status_message)
+    add_column :bulkrax_importers, :status_message, :string, default: 'Pending' unless column_exists?(:bulkrax_importers, :status_message)
+    add_column :bulkrax_exporters, :status_message, :string, default: 'Pending' unless column_exists?(:bulkrax_exporters, :status_message)
   end
 end

--- a/db/migrate/20240208005801_denormalize_status_message.rb
+++ b/db/migrate/20240208005801_denormalize_status_message.rb
@@ -1,0 +1,7 @@
+class DenormalizeStatusMessage < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bulkrax_entries, :status_message, :string, default: 'Pending'
+    add_column :bulkrax_importers, :status_message, :string, default: 'Pending'
+    add_column :bulkrax_exporters, :status_message, :string, default: 'Pending'
+  end
+end

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -3,6 +3,7 @@
 require "bulkrax/version"
 require "bulkrax/engine"
 require 'active_support/all'
+require 'denormalize_fields'
 
 # rubocop:disable Metrics/ModuleLength
 module Bulkrax

--- a/lib/tasks/bulkrax_tasks.rake
+++ b/lib/tasks/bulkrax_tasks.rake
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 namespace :bulkrax do
-
   desc 'Update all status messages from the latest status. This is to refresh the denormalized field'
-  task :update_status_messages => :environment do
+  task update_status_messages: :environment do
     @progress = ProgressBar.create(total: Bulkrax::Status.latest_by_statusable.count,
-      format:"%a %b\u{15E7}%i %c/%C %p%% %t",
-      progress_mark: ' ',
-      remainder_mark: "\u{FF65}")
+                                   format: "%a %b\u{15E7}%i %c/%C %p%% %t",
+                                   progress_mark: ' ',
+                                   remainder_mark: "\u{FF65}")
     Bulkrax::Status.latest_by_statusable.includes(:statusable).find_each do |status|
       status.statusable.update(status_message: status.status_message)
       @progress.increment

--- a/lib/tasks/bulkrax_tasks.rake
+++ b/lib/tasks/bulkrax_tasks.rake
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 namespace :bulkrax do
+
+  desc 'Update all status messages from the latest status. This is to refresh the denormalized field'
+  task :update_status_messages => :environment do
+    @progress = ProgressBar.create(total: Bulkrax::Status.latest_by_statusable.count,
+      format:"%a %b\u{15E7}%i %c/%C %p%% %t",
+      progress_mark: ' ',
+      remainder_mark: "\u{FF65}")
+    Bulkrax::Status.latest_by_statusable.includes(:statusable).find_each do |status|
+      status.statusable.update(status_message: status.status_message)
+      @progress.increment
+    end
+  end
+
   # Usage example: rails bulkrax:generate_test_csvs['5','100','GenericWork']
   desc 'Generate CSVs with fake data for testing purposes'
   task :generate_test_csvs, [:num_of_csvs, :csv_rows, :record_type] => :environment do |_t, args|


### PR DESCRIPTION
Storing the status_message on the entry will do a lot of good. It is so hard to sort and search by status right now and it just doesn't have to be. The status of an Entry is especially important. This PR also makes way for the new datatables work.

When deploying this change all objects will have the status_message "Pending" until the `bulkrax:update_status_messages` rake task is run. Call `rails bulkrax:update_status_messages` to do so. It touches every entry, so it could take a little while ☕ 

These should be kept in sync pretty faithully, but we're providing a rake task for setup and just in case.
