### PR TITLE
For every importer / record combo there should be exactly one entry

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -305,11 +305,15 @@ module Bulkrax
     end
 
     def find_or_create_entry(entryclass, identifier, type, raw_metadata = nil)
-      entry = entryclass.where(
+      # limit entry search to just this importer or exporter. Don't go moving them
+      entry = importerexporter.entries.where(
+        identifier: identifier
+      ).first
+      entry ||= entryclass.new(
         importerexporter_id: importerexporter.id,
         importerexporter_type: type,
         identifier: identifier
-      ).first_or_create!
+      )
       entry.raw_metadata = raw_metadata
       entry.save!
       entry

--- a/db/migrate/20240209070952_update_identifier_index.rb
+++ b/db/migrate/20240209070952_update_identifier_index.rb
@@ -1,0 +1,6 @@
+class UpdateIdentifierIndex < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :bulkrax_entries, :identifier if index_exists?(:bulkrax_entries, :identifier )
+    add_index :bulkrax_entries, [:identifier, :importerexporter_id, :importerexporter_type], name: 'bulkrax_identifier_idx' unless index_exists?(:bulkrax_entries, [:identifier, :importerexporter_id, :importerexporter_type], name: 'bulkrax_identifier_idx')
+  end
+end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_08_153601) do
+ActiveRecord::Schema.define(version: 2024_02_09_070952) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "name"
@@ -41,7 +41,8 @@ ActiveRecord::Schema.define(version: 2023_06_08_153601) do
     t.datetime "last_succeeded_at"
     t.string "importerexporter_type", default: "Bulkrax::Importer"
     t.integer "import_attempts", default: 0
-    t.index ["identifier"], name: "index_bulkrax_entries_on_identifier"
+    t.string "status_message", default: "Pending"
+    t.index ["identifier", "importerexporter_id", "importerexporter_type"], name: "bulkrax_identifier_idx"
     t.index ["importerexporter_id", "importerexporter_type"], name: "bulkrax_entries_importerexporter_idx"
     t.index ["type"], name: "index_bulkrax_entries_on_type"
   end
@@ -76,6 +77,7 @@ ActiveRecord::Schema.define(version: 2023_06_08_153601) do
     t.string "workflow_status"
     t.boolean "include_thumbnails", default: false
     t.boolean "generated_metadata", default: false
+    t.string "status_message", default: "Pending"
     t.index ["user_id"], name: "index_bulkrax_exporters_on_user_id"
   end
 
@@ -116,6 +118,7 @@ ActiveRecord::Schema.define(version: 2023_06_08_153601) do
     t.boolean "validate_only"
     t.datetime "last_error_at"
     t.datetime "last_succeeded_at"
+    t.string "status_message", default: "Pending"
     t.index ["user_id"], name: "index_bulkrax_importers_on_user_id"
   end
 


### PR DESCRIPTION
There were previously cases where a new importer would either steal an existing importers entry or it would update the old entry and not show it when viewing that importer. This fixes that by scoping entry identifiers to the importer or exporter that created them.