### PR TITLE
Select existing entries for update

### DIFF
--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -74,12 +74,14 @@ function handleFileToggle(file_path) {
     $('#file_path').hide()
     $('#file_upload').hide()
     $('#cloud').hide()
+    $('#existing_options').hide()
     $('#file_path input').attr('required', null)
     $('#file_upload input').attr('required', null)
   } else {
     $('#file_path').show()
     $('#file_upload').hide()
     $('#cloud').hide()
+    $('#existing_options').hide()
     $('#file_path input').attr('required', 'required')
     $('#file_upload input').attr('required', null)
     $('#importer_parser_fields_file_style_specify_a_path_on_the_server').attr('checked', true)
@@ -89,6 +91,7 @@ function handleFileToggle(file_path) {
     $('#file_path').hide()
     $('#file_upload').show()
     $('#cloud').hide()
+    $('#existing_options').hide()
     $('#file_path input').attr('required', null)
     $('#file_upload input').attr('required', 'required')
   })
@@ -96,6 +99,7 @@ function handleFileToggle(file_path) {
     $('#file_path').show()
     $('#file_upload').hide()
     $('#cloud').hide()
+    $('#existing_options').hide()
     $('#file_path input').attr('required', 'required')
     $('#file_upload input').attr('required', null)
   })
@@ -103,9 +107,19 @@ function handleFileToggle(file_path) {
     $('#file_path').hide()
     $('#file_upload').hide()
     $('#cloud').show()
+    $('#existing_options').hide()
     $('#file_path input').attr('required', null)
     $('#file_upload input').attr('required', null)
   })
+  $('#importer_parser_fields_file_style_existing_entries').click(function(e){
+    $('#file_path').hide()
+    $('#file_upload').hide()
+    $('#cloud').hide()
+    $('#existing_options').show()
+    $('#file_path input').attr('required', null)
+    $('#file_upload input').attr('required', null)
+  })
+
 }
 
 function handleParserKlass() {

--- a/app/assets/stylesheets/bulkrax/import_export.scss
+++ b/app/assets/stylesheets/bulkrax/import_export.scss
@@ -35,3 +35,8 @@ div#s2id_exporter_export_source_collection {
 .bulkrax-clear-toggles {
   clear: both;
 }
+
+#existing_options .collection_check_boxes {
+  margin-left: 10px;
+  margin-right: 10px;
+}

--- a/app/controllers/bulkrax/entries_controller.rb
+++ b/app/controllers/bulkrax/entries_controller.rb
@@ -30,7 +30,7 @@ module Bulkrax
       current_run = item.current_run(skip_counts: true)
       @entry.set_status_info('Pending', current_run)
       if params[:destroy_first]
-      "Bulkrax::DeleteAndImport#{type.camelize}Job".constantize.perform_later(@entry, current_run)
+        "Bulkrax::DeleteAndImport#{type.camelize}Job".constantize.perform_later(@entry, current_run)
       else
         "Bulkrax::Import#{type.camelize}Job".constantize.perform_later(@entry.id, current_run.id)
       end

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -218,7 +218,7 @@ module Bulkrax
     end
 
     def importable_parser_fields
-      params&.[](:importer)&.[](:parser_fields)&.except(:file, :entry_statuses)&.keys + [{"entry_statuses"=>[]}]
+      params&.[](:importer)&.[](:parser_fields)&.except(:file, :entry_statuses)&.keys&. + [{ "entry_statuses" => [] }]
     end
 
     # Only allow a trusted parameters through.

--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -218,7 +218,7 @@ module Bulkrax
     end
 
     def importable_parser_fields
-      params&.[](:importer)&.[](:parser_fields)&.except(:file)&.keys
+      params&.[](:importer)&.[](:parser_fields)&.except(:file, :entry_statuses)&.keys + [{"entry_statuses"=>[]}]
     end
 
     # Only allow a trusted parameters through.

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -168,7 +168,7 @@ module Bulkrax
     end
 
     def existing_entries?
-      parser.parser_fields['file_style'].match(/Existing Entries/)
+      parser.parser_fields['file_style']&.match(/Existing Entries/)
     end
 
     def import_works

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -167,6 +167,10 @@ module Bulkrax
       parser.parser_fields['metadata_only'] == true
     end
 
+    def existing_entries?
+      parser.parser_fields['file_style'].match(/Existing Entries/)
+    end
+
     def import_works
       import_objects(['work'])
     end
@@ -189,7 +193,7 @@ module Bulkrax
       self.only_updates ||= false
       self.save if self.new_record? # Object needs to be saved for statuses
       types = types_array || DEFAULT_OBJECT_TYPES
-      parser.create_objects(types)
+      existing_entries? ? parser.rebuild_entries(types) : parser.create_objects(types)
       mark_unseen_as_skipped
     rescue StandardError => e
       set_status_info(e)

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -209,6 +209,20 @@ module Bulkrax
       set_status_info(e)
     end
 
+    def rebuild_entries(types_array = nil)
+      index = 0
+      importer.entries.where(status_message: parser_fields['entry_statuses']).find_each do |e|
+        seen[e.identifier] = true
+        if remove_and_rerun
+          "Bulkrax::DeleteAndImport#{type.camelize}Job".constantize.send(perform_method, e, current_run)
+        else
+          "Bulkrax::Import#{type.camelize}Job".constantize.send(perform_method, e.id, current_run.id)
+        end
+        increment_counters(index)
+        index += 1
+      end
+    end
+
     def create_entry_and_job(current_record, type, identifier = nil)
       identifier ||= current_record[source_identifier]
       new_entry = find_or_create_entry(send("#{type}_entry_class"),

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -209,7 +209,7 @@ module Bulkrax
       set_status_info(e)
     end
 
-    def rebuild_entries(types_array = nil)
+    def rebuild_entries(_types_array = nil)
       index = 0
       importer.entries.where(status_message: parser_fields['entry_statuses']).find_each do |e|
         seen[e.identifier] = true

--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -25,13 +25,17 @@
   <h4>Add CSV File to Import:</h4>
   <%# accept a single file upload; data files and bags will need to be added another way %>
 
-  <%= fi.input :file_style, collection: ['Upload a File', 'Specify a Path on the Server'], as: :radio_buttons, label: false %>
+  <%= fi.input :file_style, collection: ['Upload a File', 'Specify a Path on the Server', 'Existing Entries'], as: :radio_buttons, label: false %>
   <div id='file_upload'>
     <%= fi.input 'file', as: :file, input_html: { accept: 'text/csv,application/zip' } %><br />
   </div>
   <div id='file_path'>
     <%= fi.input :import_file_path, as: :string, input_html: { value: importer.parser_fields['import_file_path'] } %>
   </div>
+  <div id='existing_options'>
+    <%= fi.collection_check_boxes :entry_statuses, [['Failed'], ['Pending'], ['Skipped'], ['Deleted'], ['Complete']], :first, :first %>
+  </div>
+
   <% if defined?(::Hyrax) && Hyrax.config.browse_everything? %>
 	  <h4>Add Files to Import:</h4>
 	  <p>Choose files to upload. The filenames must be unique, and the filenames must be referenced in a column called 'file' in the accompanying CSV file.</p>


### PR DESCRIPTION
Adds an option to select existing entries by status when updating an importer. The source file will not be reread, the works simply get built or removed and built again.


[screenshot](https://share.zight.com/RBuklK2w)