### PR TITLE
Fix exporters show page - 2

### DIFF
--- a/app/assets/javascripts/bulkrax/datatables.js
+++ b/app/assets/javascripts/bulkrax/datatables.js
@@ -56,6 +56,29 @@ Blacklight.onLoad(function() {
     } );
   }
 
+  if($('#exporters-table').length) {
+    $('#exporters-table').DataTable( {
+      'processing': true,
+      'serverSide': true,
+      "ajax": window.location.href.replace(/(\/exporters)/, "$1/exporter_table.json"),
+      "pageLength": 30,
+      "lengthMenu": [[30, 100, 200], [30, 100, 200]],
+      "columns": [
+        { "data": "name" },
+        { "data": "status_message" },
+        { "data": "created_at" },
+        { "data": "download" },
+        { "data": "actions", "orderable": false }
+      ],
+      initComplete: function () {
+        // Add status filter
+        statusSelect.bind(this)()
+        // Add refresh link
+        refreshLink.bind(this)()
+      }
+    } );
+  }
+
 })
 
 function entrySelect() {

--- a/app/assets/javascripts/bulkrax/datatables.js
+++ b/app/assets/javascripts/bulkrax/datatables.js
@@ -3,7 +3,7 @@ Blacklight.onLoad(function() {
     $('#importer-show-table').DataTable( {
       'processing': true,
       'serverSide': true,
-      "ajax": window.location.href.replace(/(\/importers\/\d+)/, "$1/entry_table.json"),
+      "ajax": window.location.href.replace(/(\/(importers|exporters)\/\d+)/, "$1/entry_table.json"),
       "pageLength": 30,
       "lengthMenu": [[30, 100, 200], [30, 100, 200]],
       "columns": [

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -18,7 +18,7 @@ module Bulkrax
       add_exporter_breadcrumbs if defined?(::Hyrax)
     end
 
-    def importer_table
+    def exporter_table
       @exporters = Exporter.order(table_order).page(table_page).per(table_per_page)
       @exporters = @exporters.where(exporter_table_search) if exporter_table_search.present?
       respond_to do |format|

--- a/app/controllers/bulkrax/exporters_controller.rb
+++ b/app/controllers/bulkrax/exporters_controller.rb
@@ -4,9 +4,10 @@ module Bulkrax
   class ExportersController < ApplicationController
     include Hyrax::ThemedLayoutController if defined?(::Hyrax)
     include Bulkrax::DownloadBehavior
+    include Bulkrax::DatatablesBehavior
     before_action :authenticate_user!
     before_action :check_permissions
-    before_action :set_exporter, only: [:show, :edit, :update, :destroy]
+    before_action :set_exporter, only: [:show, :entry_table, :edit, :update, :destroy]
     with_themed_layout 'dashboard' if defined?(::Hyrax)
 
     # GET /exporters
@@ -17,16 +18,29 @@ module Bulkrax
       add_exporter_breadcrumbs if defined?(::Hyrax)
     end
 
+    def importer_table
+      @exporters = Exporter.order(table_order).page(table_page).per(table_per_page)
+      @exporters = @exporters.where(exporter_table_search) if exporter_table_search.present?
+      respond_to do |format|
+        format.json { render json: format_exporters(@exporters) }
+      end
+    end
+
     # GET /exporters/1
     def show
       if defined?(::Hyrax)
         add_exporter_breadcrumbs
         add_breadcrumb @exporter.name
       end
+      @first_entry = @exporter.entries.first
+    end
 
-      @work_entries = @exporter.entries.where(type: @exporter.parser.entry_class.to_s).page(params[:work_entries_page]).per(30)
-      @collection_entries = @exporter.entries.where(type: @exporter.parser.collection_entry_class.to_s).page(params[:collections_entries_page]).per(30)
-      @file_set_entries = @exporter.entries.where(type: @exporter.parser.file_set_entry_class.to_s).page(params[:file_set_entries_page]).per(30)
+    def entry_table
+      @entries = @exporter.entries.order(table_order).page(table_page).per(table_per_page)
+      @entries = @entries.where(entry_table_search) if entry_table_search.present?
+      respond_to do |format|
+        format.json { render json: format_entries(@entries, @exporter) }
+      end
     end
 
     # GET /exporters/new
@@ -100,7 +114,7 @@ module Bulkrax
 
     # Use callbacks to share common setup or constraints between actions.
     def set_exporter
-      @exporter = Exporter.find(params[:id])
+      @exporter = Exporter.find(params[:id] || params[:exporter_id])
     end
 
     # Only allow a trusted parameters through.

--- a/app/views/bulkrax/exporters/index.html.erb
+++ b/app/views/bulkrax/exporters/index.html.erb
@@ -13,62 +13,18 @@
 
 <div class="panel panel-default">
   <div class="panel-body">
-    <% if @exporters.present? %>
-      <div class="table-responsive">
-        <table class="table table-striped datatable">
-          <thead>
-            <tr>
-              <th scope="col">Name</th>
-              <th scope="col">Status</th>
-              <th scope="col">Date Exported</th>
-              <th scope="col">Downloadable Files</th>
-              <th scope="col"></th>
-              <th scope="col"></th>
-              <th scope="col"></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @exporters.each do |exporter| %>
-              <tr>
-                <th scope="row"><%= link_to exporter.name, exporter_path(exporter) %></th>
-                <td><%= exporter.status %></td>
-                <td><%= exporter.created_at %></td>
-                <td>
-                  <% if File.exist?(exporter.exporter_export_zip_path) %>
-                    <%= simple_form_for(exporter, method: :get, url: exporter_download_path(exporter)) do |form| %>
-                      <%= render 'downloads', exporter: exporter, form: form %>
-                      <%= form.button :submit, value: 'Download', data: { disable_with: false } %>
-                    <% end %>
-                  <% end%>
-                </td>
-                <td><%= link_to raw('<span class="glyphicon glyphicon-info-sign"></span>'), exporter_path(exporter) %></td>
-                <td><%= link_to raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_exporter_path(exporter), data: { turbolinks: false } %></td>
-                <td><%= link_to raw('<span class="glyphicon glyphicon-remove"></span>'), exporter, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-      <% else %>
-        <p>No exporters have been created.</p>
-      <% end %>
+    <div class="table-responsive">
+      <table id='exporters-table' class="table table-striped">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Status</th>
+            <th scope="col">Date Exported</th>
+            <th scope="col">Downloadable Files</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+      </table>
+    </div>
   </div>
 </div>
-
-<script>
-  $(function() {
-    $('#DataTables_Table_0').DataTable({
-      destroy: true, /* Reinitialize DataTable with config below */
-      'columnDefs': [
-          { 'orderable': true, 'targets': [0, 1, 2] },
-          { 'orderable': false, 'targets': [3, 4, 5, 6] }
-      ],
-      'language': {
-        'info': 'Showing _START_ to _END_ of _TOTAL_ exporters',
-        'infoEmpty': 'No exporters to show',
-        'infoFiltered': '(filtered from _MAX_ total exporters)',
-        'lengthMenu': 'Show _MENU_ exporters'
-      }
-    })
-  })
-</script>

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -95,18 +95,9 @@
 
     <div class="bulkrax-nav-tab-bottom-margin">
       <!-- Nav tabs -->
-      <ul class="bulkrax-nav-tab-top-margin tab-nav nav nav-tabs" role="tablist">
-        <li role="presentation" class="nav-link active"><a href="#work-entries" aria-controls="work-entries" role="tab" data-toggle="tab"><%= t('bulkrax.exporter.labels.work_entries') %></a></li>
-        <li role="presentation" class="nav-link"><a href="#collection-entries" aria-controls="collection-entries" role="tab" data-toggle="tab"><%= t('bulkrax.exporter.labels.collection_entries') %></a></li>
-        <li role="presentation" class="nav-link"><a href="#file-set-entries" aria-controls="file-set-entries" role="tab" data-toggle="tab"><%= t('bulkrax.exporter.labels.file_set_entries') %></a></li>
-      </ul>
-      <!-- Tab panes -->
-      <div class="tab-content outline">
-        <%= render partial: 'bulkrax/shared/entries_tab', locals: { item: @exporter, entries: @work_entries, pagination_param_name:  :work_entries_page, pagination_anchor: 'work-entries' } %>
-        <%= render partial: 'bulkrax/shared/entries_tab', locals: { item: @exporter, entries: @collection_entries, pagination_param_name: :collection_entries_path, pagination_anchor: 'collection-entries' } %>
-        <%= render partial: 'bulkrax/shared/entries_tab', locals: { item: @exporter, entries: @file_set_entries, pagination_param_name: :file_set_entries_path, pagination_anchor: 'file-set-entries' } %>
+      <div class="outline">
+        <%= render partial: 'bulkrax/shared/entries_tab' %>
       </div>
-
       <br>
       <%= link_to 'Edit', edit_exporter_path(@exporter) %>
       |

--- a/app/views/bulkrax/exporters/show.html.erb
+++ b/app/views/bulkrax/exporters/show.html.erb
@@ -96,7 +96,7 @@
     <div class="bulkrax-nav-tab-bottom-margin">
       <!-- Nav tabs -->
       <div class="outline">
-        <%= render partial: 'bulkrax/shared/entries_tab' %>
+        <%= render partial: 'bulkrax/shared/entries_tab', locals: { item: @exporter } %>
       </div>
       <br>
       <%= link_to 'Edit', edit_exporter_path(@exporter) %>

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -77,7 +77,7 @@
     <div class="bulkrax-nav-tab-bottom-margin">
       <!-- Nav tabs -->
       <div class="outline">
-        <%= render partial: 'bulkrax/shared/entries_tab' %>
+        <%= render partial: 'bulkrax/shared/entries_tab', locals: { item: @importer} %>
       </div>
       <%= render partial: 'bulkrax/importers/edit_item_buttons', locals: { item: @importer, e: @first_entry } if @first_entry.present? %>
     </div>

--- a/app/views/bulkrax/shared/_entries_tab.html.erb
+++ b/app/views/bulkrax/shared/_entries_tab.html.erb
@@ -12,5 +12,5 @@
       </tr>
     </thead>
   </table>
-  <div id='<%= "importer-entry-classes" %>' class='hidden'><%= [item.parser.entry_class.to_s, item.parser.collection_entry_class.to_s, item.parser.file_set_entry_class.to_s].compact.join('|') %></div>
+  <div id='importer-entry-classes' class='hidden'><%= [item.parser.entry_class.to_s, item.parser.collection_entry_class.to_s, item.parser.file_set_entry_class.to_s].compact.join('|') %></div>
 </div>

--- a/app/views/bulkrax/shared/_entries_tab.html.erb
+++ b/app/views/bulkrax/shared/_entries_tab.html.erb
@@ -12,5 +12,6 @@
       </tr>
     </thead>
   </table>
-  <div id='importer-entry-classes' class='hidden'><%= [@importer.parser.entry_class.to_s, @importer.parser.collection_entry_class.to_s, @importer.parser.file_set_entry_class.to_s].compact.join('|') %></div>
+  <% agent = instance_variable_get("@#{controller.controller_name.singularize}") %>
+  <div id='<%= "importer-entry-classes" %>' class='hidden'><%= [agent.parser.entry_class.to_s, agent.parser.collection_entry_class.to_s, agent.parser.file_set_entry_class.to_s].compact.join('|') %></div>
 </div>

--- a/app/views/bulkrax/shared/_entries_tab.html.erb
+++ b/app/views/bulkrax/shared/_entries_tab.html.erb
@@ -12,7 +12,5 @@
       </tr>
     </thead>
   </table>
-  <% agent = instance_variable_get("@#{controller.controller_name.singularize}") %>
-  <div id='<%= "importer-entry-classes" %>' class='hidden'><%= [item.parser.entry_class.to_s,
-  item.parser.collection_entry_class.to_s,         item.parser.file_set_entry_class.to_s].compact.join('|') %></div>
+  <div id='<%= "importer-entry-classes" %>' class='hidden'><%= [item.parser.entry_class.to_s, item.parser.collection_entry_class.to_s, item.parser.file_set_entry_class.to_s].compact.join('|') %></div>
 </div>

--- a/app/views/bulkrax/shared/_entries_tab.html.erb
+++ b/app/views/bulkrax/shared/_entries_tab.html.erb
@@ -13,5 +13,6 @@
     </thead>
   </table>
   <% agent = instance_variable_get("@#{controller.controller_name.singularize}") %>
-  <div id='<%= "importer-entry-classes" %>' class='hidden'><%= [agent.parser.entry_class.to_s, agent.parser.collection_entry_class.to_s, agent.parser.file_set_entry_class.to_s].compact.join('|') %></div>
+  <div id='<%= "importer-entry-classes" %>' class='hidden'><%= [item.parser.entry_class.to_s,
+  item.parser.collection_entry_class.to_s,         item.parser.file_set_entry_class.to_s].compact.join('|') %></div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Bulkrax::Engine.routes.draw do
   resources :exporters do
     get :download
+    get :entry_table
     resources :entries, only: %i[show update destroy]
   end
   resources :importers do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Bulkrax::Engine.routes.draw do
   resources :exporters do
     get :download
     get :entry_table
+    collection do
+      get :exporter_table
+    end
     resources :entries, only: %i[show update destroy]
   end
   resources :importers do


### PR DESCRIPTION
![exporters](https://github.com/samvera/bulkrax/assets/19597776/7548f42e-500f-4f40-9096-5ec9a0ef20f7)

Mimicking the importers show page, this change adds support for the datatables.js to the exporters show page.
