### PR TITLE
♻️ Favor configuration over hard-coding

### DIFF
--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -40,7 +40,7 @@ module Bulkrax
 
     include DynamicRecordLookup
 
-    queue_as :import
+    queue_as Bulkrax.config.ingest_queue_name
 
     # @param parent_identifier [String] Work/Collection ID or Bulkrax::Entry source_identifiers
     # @param importer_run [Bulkrax::ImporterRun] current importer run (needed to properly update counters)

--- a/app/jobs/bulkrax/delete_job.rb
+++ b/app/jobs/bulkrax/delete_job.rb
@@ -2,7 +2,7 @@
 
 module Bulkrax
   class DeleteJob < ApplicationJob
-    queue_as :import
+    queue_as Bulkrax.config.ingest_queue_name
 
     def perform(entry, importer_run)
       obj = entry.factory.find

--- a/app/jobs/bulkrax/download_cloud_file_job.rb
+++ b/app/jobs/bulkrax/download_cloud_file_job.rb
@@ -2,7 +2,7 @@
 
 module Bulkrax
   class DownloadCloudFileJob < ApplicationJob
-    queue_as :import
+    queue_as Bulkrax.config.ingest_queue_name
 
     # Retrieve cloud file and write to the imports directory
     # Note: if using the file system, the mounted directory in

--- a/app/jobs/bulkrax/import_collection_job.rb
+++ b/app/jobs/bulkrax/import_collection_job.rb
@@ -2,7 +2,7 @@
 
 module Bulkrax
   class ImportCollectionJob < ApplicationJob
-    queue_as :import
+    queue_as Bulkrax.config.ingest_queue_name
 
     # rubocop:disable Rails/SkipsModelValidations
     def perform(*args)

--- a/app/jobs/bulkrax/import_file_set_job.rb
+++ b/app/jobs/bulkrax/import_file_set_job.rb
@@ -6,7 +6,7 @@ module Bulkrax
   class ImportFileSetJob < ApplicationJob
     include DynamicRecordLookup
 
-    queue_as :import
+    queue_as Bulkrax.config.ingest_queue_name
 
     attr_reader :importer_run_id
 

--- a/app/jobs/bulkrax/import_work_job.rb
+++ b/app/jobs/bulkrax/import_work_job.rb
@@ -2,7 +2,7 @@
 
 module Bulkrax
   class ImportWorkJob < ApplicationJob
-    queue_as :import
+    queue_as Bulkrax.config.ingest_queue_name
 
     # rubocop:disable Rails/SkipsModelValidations
     #

--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -2,7 +2,7 @@
 
 module Bulkrax
   class ImporterJob < ApplicationJob
-    queue_as :import
+    queue_as Bulkrax.config.ingest_queue_name
 
     def perform(importer_id, only_updates_since_last_import = false)
       importer = Importer.find(importer_id)

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -63,6 +63,15 @@ module Bulkrax
       @factory_class_name_coercer || Bulkrax::FactoryClassFinder::DefaultCoercer
     end
 
+    attr_writer :ingest_queue_name
+    ##
+    # @return [String, Proc]
+    def ingest_queue_name
+      return @ingest_queue_name if @ingest_queue_name.present?
+      return Hyrax.config.ingest_queue_name if defined?(Hyrax)
+      :import
+    end
+
     ##
     # Configure the persistence adapter used for persisting imported data.
     #


### PR DESCRIPTION
Given that Hyrax provides a mechanism for specifying a queue name, we should echo that configuration, but also provide our own configuration as well as the same fallback.