### PR TITLE
🐛 Fix exporter page for Bootstrap 3 applications

### DIFF
--- a/app/assets/javascripts/bulkrax/exporters.js
+++ b/app/assets/javascripts/bulkrax/exporters.js
@@ -26,14 +26,14 @@ function removeRequired(allSources) {
 
 // hide all export_source
 function hide(allSources) {
-  allSources.addClass('d-none');
-  allSources.find('#exporter_export_source').addClass('.d-none').attr('type', 'd-none');
+  allSources.addClass('d-none hidden');
+  allSources.find('#exporter_export_source').addClass('.d-none hidden').attr('type', 'd-none hidden');
 }
 
 // unhide selected export_source
 function unhideSelected(selectedSource) {
-  selectedSource.removeClass('d-none').removeAttr('type');
-  selectedSource.parent().removeClass('d-none').removeAttr('type');
+  selectedSource.removeClass('d-none hidden').removeAttr('type');
+  selectedSource.parent().removeClass('d-none hidden').removeAttr('type');
 };
 
 // add the autocomplete javascript

--- a/app/controllers/concerns/bulkrax/datatables_behavior.rb
+++ b/app/controllers/concerns/bulkrax/datatables_behavior.rb
@@ -174,7 +174,7 @@ module Bulkrax
     def exporter_util_links(i)
       links = []
       links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-info-sign"></span>'), exporter_path(i))
-      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_exporter_path(i))
+      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_exporter_path(i), data: { turbolinks: false })
       links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
       links.join(" ")
     end

--- a/app/views/bulkrax/exporters/_form.html.erb
+++ b/app/views/bulkrax/exporters/_form.html.erb
@@ -33,8 +33,8 @@
     label: t('bulkrax.exporter.labels.importer'),
     required: true,
     prompt: 'Select from the list',
-    label_html: { class: 'importer export-source-option d-none' },
-    input_html: { class: 'importer export-source-option d-none form-control' },
+    label_html: { class: 'importer export-source-option d-none hidden' },
+    input_html: { class: 'importer export-source-option d-none hidden form-control' },
     collection:  form.object.importers_list.sort %>
 
   <%= form.input :export_source_collection,
@@ -42,9 +42,9 @@
     label: t('bulkrax.exporter.labels.collection'),
     required: true,
     placeholder: @collection&.title&.first,
-    label_html: { class: 'collection export-source-option d-none' },
+    label_html: { class: 'collection export-source-option d-none hidden' },
     input_html: {
-      class: 'collection export-source-option d-none form-control',
+      class: 'collection export-source-option d-none hidden form-control',
       data: {
         'autocomplete-url' => '/authorities/search/collections',
         'autocomplete' => 'collection'
@@ -56,8 +56,8 @@
     label: t('bulkrax.exporter.labels.worktype'),
     required: true,
     prompt: 'Select from the list',
-    label_html: { class: 'worktype export-source-option d-none' },
-    input_html: { class: 'worktype export-source-option d-none form-control' },
+    label_html: { class: 'worktype export-source-option d-none hidden' },
+    input_html: { class: 'worktype export-source-option d-none hidden form-control' },
     collection: Bulkrax.curation_concerns.map { |cc| [cc.to_s, cc.to_s] } %>
 
   <%= form.input :limit,
@@ -80,7 +80,7 @@
                  as: :boolean,
                  label: t('bulkrax.exporter.labels.filter_by_date') %>
 
-  <div id="date_filter_picker" class="d-none">
+  <div id="date_filter_picker" class="d-none hidden">
     <%= form.input :start_date,
                    as: :date,
                    label: t('bulkrax.exporter.labels.start_date'),
@@ -136,13 +136,13 @@
             // get the date filter option and show the corresponding date selectors
             $('.exporter_date_filter').change(function () {
                 if ($('.exporter_date_filter').find(".boolean").is(":checked"))
-                    $('#date_filter_picker').removeClass('d-none');
+                    $('#date_filter_picker').removeClass('d-none hidden');
                 else
-                    $('#date_filter_picker').addClass('d-none');
+                    $('#date_filter_picker').addClass('d-none hidden');
             });
 
             if ($('.exporter_date_filter').find(".boolean").is(":checked"))
-                $('#date_filter_picker').removeClass('d-none');
+                $('#date_filter_picker').removeClass('d-none hidden');
         });
     });
 </script>


### PR DESCRIPTION
This commit will add the `hidden` class back in addition to the `d-none` class.  This way older Hyku/Hyrax applications can still use it without unintended effects.  Also, adding a turbolinks false to the edit exporter link because the buttons on the form page was not working without a refresh.