### PR TITLE
♻️ Favor member_ids_ssim over file_set_ids_ssim

### DIFF
--- a/app/parsers/bulkrax/parser_export_record_set.rb
+++ b/app/parsers/bulkrax/parser_export_record_set.rb
@@ -120,7 +120,7 @@ module Bulkrax
       #
       # No sense attempting to query for more than the limit.
       def query_kwargs
-        { fl: "id,member_ids_ssim", method: :post, rows: row_limit }
+        { fl: "id,#{Bulkrax.solr_key_for_member_file_ids}", method: :post, rows: row_limit }
       end
 
       # If we have a limit, we need not query beyond that limit

--- a/app/parsers/bulkrax/parser_export_record_set.rb
+++ b/app/parsers/bulkrax/parser_export_record_set.rb
@@ -113,14 +113,14 @@ module Bulkrax
       #
       # @see #file_sets
       def candidate_file_set_ids
-        @candidate_file_set_ids ||= works.flat_map { |work| work.fetch("#{Bulkrax.file_model_class.to_s.underscore}_ids_ssim", []) }
+        @candidate_file_set_ids ||= works.flat_map { |work| work.fetch(Bulkrax.solr_key_for_member_file_ids, []) }
       end
 
       # @note Specifically not memoizing this so we can merge values without changing the object.
       #
       # No sense attempting to query for more than the limit.
       def query_kwargs
-        { fl: "id,#{Bulkrax.file_model_class.to_s.underscore}_ids_ssim", method: :post, rows: row_limit }
+        { fl: "id,member_ids_ssim", method: :post, rows: row_limit }
       end
 
       # If we have a limit, we need not query beyond that limit

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -45,6 +45,21 @@ module Bulkrax
     attr_writer :persistence_adapter
 
     ##
+    # @param [String]
+    attr_writer :solr_key_for_member_file_ids
+
+    ##
+    # @return [String]
+    # @see https://github.com/samvera/hyrax/pull/6513
+    def solr_key_for_member_file_ids
+      return @solr_key_for_member_file_ids if @solr_key_for_member_file_ids.present?
+
+      return "member_ids_ssim" if defined?(Hyrax)
+
+      "#{file_model_class.name.to_s.underscore}_ids_ssim"
+    end
+
+    ##
     # @param coercer [#call]
     # @see Bulkrax::FactoryClassFinder
     attr_writer :factory_class_name_coercer
@@ -157,6 +172,8 @@ module Bulkrax
                  :reserved_properties=,
                  :server_name,
                  :server_name=,
+                 :solr_key_for_member_file_ids,
+                 :solr_key_for_member_file_ids=,
                  :use_locking,
                  :use_locking=,
                  :use_locking?

--- a/spec/parsers/bulkrax/parser_export_record_set_spec.rb
+++ b/spec/parsers/bulkrax/parser_export_record_set_spec.rb
@@ -61,8 +61,8 @@ end
   RSpec.describe klass do
     let(:works) do
       [
-        SolrDocument.new(id: 1, file_set_ids_ssim: ["a", "b", "c"]),
-        SolrDocument.new(id: 2, file_set_ids_ssim: ["d", "e", "f"])
+        SolrDocument.new(id: 1, member_ids_ssim: ["a", "b", "c"]),
+        SolrDocument.new(id: 2, member_ids_ssim: ["d", "e", "f"])
       ]
     end
 
@@ -132,7 +132,7 @@ end
                    [works[1].id, parser.entry_class],
                    [collections[0].id, parser.collection_entry_class],
                    [collections[1].id, parser.collection_entry_class],
-                   [works[0].fetch("file_set_ids_ssim").first, parser.file_set_entry_class]
+                   [works[0].fetch(Bulkrax.solr_key_for_member_file_ids).first, parser.file_set_entry_class]
                  )
         end
       end
@@ -147,12 +147,12 @@ end
                    [works[1].id, parser.entry_class],
                    [collections[0].id, parser.collection_entry_class],
                    [collections[1].id, parser.collection_entry_class],
-                   [works[0].fetch("file_set_ids_ssim")[0], parser.file_set_entry_class],
-                   [works[0].fetch("file_set_ids_ssim")[1], parser.file_set_entry_class],
-                   [works[0].fetch("file_set_ids_ssim")[2], parser.file_set_entry_class],
-                   [works[1].fetch("file_set_ids_ssim")[0], parser.file_set_entry_class],
-                   [works[1].fetch("file_set_ids_ssim")[1], parser.file_set_entry_class],
-                   [works[1].fetch("file_set_ids_ssim")[2], parser.file_set_entry_class]
+                   [works[0].fetch(Bulkrax.solr_key_for_member_file_ids)[0], parser.file_set_entry_class],
+                   [works[0].fetch(Bulkrax.solr_key_for_member_file_ids)[1], parser.file_set_entry_class],
+                   [works[0].fetch(Bulkrax.solr_key_for_member_file_ids)[2], parser.file_set_entry_class],
+                   [works[1].fetch(Bulkrax.solr_key_for_member_file_ids)[0], parser.file_set_entry_class],
+                   [works[1].fetch(Bulkrax.solr_key_for_member_file_ids)[1], parser.file_set_entry_class],
+                   [works[1].fetch(Bulkrax.solr_key_for_member_file_ids)[2], parser.file_set_entry_class]
                  )
         end
       end
@@ -167,12 +167,12 @@ end
                    [works[1].id, parser.entry_class],
                    [collections[0].id, parser.collection_entry_class],
                    [collections[1].id, parser.collection_entry_class],
-                   [works[0].fetch("file_set_ids_ssim")[0], parser.file_set_entry_class],
-                   [works[0].fetch("file_set_ids_ssim")[1], parser.file_set_entry_class],
-                   [works[0].fetch("file_set_ids_ssim")[2], parser.file_set_entry_class],
-                   [works[1].fetch("file_set_ids_ssim")[0], parser.file_set_entry_class],
-                   [works[1].fetch("file_set_ids_ssim")[1], parser.file_set_entry_class],
-                   [works[1].fetch("file_set_ids_ssim")[2], parser.file_set_entry_class]
+                   [works[0].fetch(Bulkrax.solr_key_for_member_file_ids)[0], parser.file_set_entry_class],
+                   [works[0].fetch(Bulkrax.solr_key_for_member_file_ids)[1], parser.file_set_entry_class],
+                   [works[0].fetch(Bulkrax.solr_key_for_member_file_ids)[2], parser.file_set_entry_class],
+                   [works[1].fetch(Bulkrax.solr_key_for_member_file_ids)[0], parser.file_set_entry_class],
+                   [works[1].fetch(Bulkrax.solr_key_for_member_file_ids)[1], parser.file_set_entry_class],
+                   [works[1].fetch(Bulkrax.solr_key_for_member_file_ids)[2], parser.file_set_entry_class]
                  )
         end
       end


### PR DESCRIPTION
For several years Hyrax has index `file_set_ids_ssim` as a verbatim copy of `member_ids_ssim`.  With Hyrax 5, we're removing the `file_set_ids_ssim` from indexing; And given that it's been a verbatim copy since 2017 or so, it's relatively safe to assume that we can favor, without application impact, the `member_ids_ssim` over the `file_set_ids_ssim` value.

It would be nice to have `file_set_ids_ssim` but not as a verbatim copy. Someday, we might have nice things.

In the case of Bulkrax, given that we don't require Hyrax, we need to have a configurable option as well as one that is a consistent fallback to what came before.

Related to:
- https://github.com/samvera/hyrax/pull/6513
- https://github.com/samvera/hyrax/commit/7108409c619cd2ba4ae8c836b9f3b429a7e9837b