### PR TITLE
♻️ Favor configuration over hard-coding and reaching assumptions

### DIFF
--- a/app/jobs/bulkrax/import_file_set_job.rb
+++ b/app/jobs/bulkrax/import_file_set_job.rb
@@ -63,8 +63,11 @@ module Bulkrax
     end
 
     def check_parent_is_a_work!(parent_identifier)
-      error_msg = %(A record with the ID "#{parent_identifier}" was found, but it was a #{parent_record.class}, which is not an valid/available work type)
-      raise ::StandardError, error_msg unless curation_concern?(parent_record)
+      case parent_record
+      when Collection, Bulkrax.file_model_class
+        error_msg = %(A record with the ID "#{parent_identifier}" was found, but it was a #{parent_record.class}, which is not an valid/available work type)
+        raise ::StandardError, error_msg
+      end
     end
 
     def find_parent_record(parent_identifier)

--- a/app/models/concerns/bulkrax/dynamic_record_lookup.rb
+++ b/app/models/concerns/bulkrax/dynamic_record_lookup.rb
@@ -28,22 +28,5 @@ module Bulkrax
       # also accounts for when the found entry isn't a part of this importer
       record.is_a?(Entry) ? [record, record.factory.find] : [nil, record]
     end
-
-    # Check if the record is a Work
-    def curation_concern?(record)
-      available_work_types.include?(record.class)
-    end
-
-    private
-
-    # @return [Array<Class>] list of work type classes
-    def available_work_types
-      # If running in a Hyku app, do not include disabled work types
-      @available_work_types ||= if defined?(::Hyku)
-                                  ::Site.instance.available_works.map(&:constantize)
-                                else
-                                  Bulkrax.curation_concerns
-                                end
-    end
   end
 end

--- a/spec/jobs/bulkrax/import_file_set_job_spec.rb
+++ b/spec/jobs/bulkrax/import_file_set_job_spec.rb
@@ -176,7 +176,7 @@ module Bulkrax
           end
 
           context 'when it references a file set' do
-            let(:non_work) { instance_double(::FileSet) }
+            let(:non_work) { Bulkrax.file_model_class.new }
 
             it 'raises an error' do
               expect { import_file_set_job.perform(entry.id, importer_run.id) }

--- a/spec/support/dynamic_record_lookup.rb
+++ b/spec/support/dynamic_record_lookup.rb
@@ -97,31 +97,5 @@ module Bulkrax
         end
       end
     end
-
-    describe '#curation_concern?' do
-      context 'when record is a work' do
-        let(:record) { build(:work) }
-
-        it 'returns true' do
-          expect(subject.curation_concern?(record)).to eq(true)
-        end
-      end
-
-      context 'when record is a collection' do
-        let(:record) { build(:collection) }
-
-        it 'returns false' do
-          expect(subject.curation_concern?(record)).to eq(false)
-        end
-      end
-
-      context 'when record is an Entry' do
-        let(:record) { build(:bulkrax_entry) }
-
-        it 'returns false' do
-          expect(subject.curation_concern?(record)).to eq(false)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
The main "flip" of logic is that we can remove the `curation_concern?` method because we can instead ask "if Collection || FileSet" and infer when that is false that we have a work.

This means removing the very reaching assumption of Hyku and it's implementation foibles for work types.