### PR TITLE
Extract method

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -6,6 +6,31 @@ module Bulkrax
     include Bulkrax::FileFactory
     include DynamicRecordLookup
 
+    ##
+    # @param value [String]
+    # @param field [String, Symbol] A convenience parameter where we pass the
+    #        same value to search_field and name_field.
+    # @param search_field [String, Symbol] the Solr field name (e.g. "title_tesim")
+    # @param name_field [String] the ActiveFedora::Base property name (e.g. "title")
+    # @param klass [Class, #where]
+    # @return [NilClass] when no object is found.
+    # @return [ActiveFedora::Base] when a match is found, an instance of given :klass
+    def self.search_by_property(value:, field: nil, search_field: nil, name_field: nil, klass: ActiveFedora::Base)
+      search_field ||= field
+      name_field ||= field
+      raise "You must provide either (search_field AND name_field) OR field parameters" if search_field.nil? || name_field.nil?
+      # NOTE: Query can return partial matches (something6 matches both
+      # something6 and something68) so we need to weed out any that are not the
+      # correct full match. But other items might be in the multivalued field,
+      # so we have to go through them one at a time.
+      #
+      # A ssi field is string, so we're looking at exact matches.
+      # A tesi field is text, so partial matches work.
+      #
+      match = klass.where(search_field => value).detect { |m| m.send(name_field).include?(value) }
+      return match if match
+    end
+
     # @api private
     #
     # These are the attributes that we assume all "work type" classes (e.g. the given :klass) will
@@ -104,13 +129,12 @@ module Bulkrax
     end
 
     def search_by_identifier
-      query = { work_identifier_search_field =>
-                source_identifier_value }
-      # Query can return partial matches (something6 matches both something6 and something68)
-      # so we need to weed out any that are not the correct full match. But other items might be
-      # in the multivalued field, so we have to go through them one at a time.
-      match = klass.where(query).detect { |m| m.send(work_identifier).include?(source_identifier_value) }
-      return match if match
+      self.class.search_by_property(
+        klass: klass,
+        search_field: work_identifier_search_field,
+        value: source_identifier_value,
+        name_field: work_identifier
+      )
     end
 
     # An ActiveFedora bug when there are many habtm <-> has_many associations means they won't all get saved.

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -103,22 +103,18 @@ module Bulkrax
       self.importerexporter_type == 'Bulkrax::Exporter'
     end
 
-    def valid_system_id(model_class)
-      return true if model_class.properties.keys.include?(work_identifier)
-      raise(
-        "#{model_class} does not implement the system_identifier_field: #{work_identifier}"
-      )
-    end
-
     def last_run
       self.importerexporter&.last_run
     end
 
     def find_collection(collection_identifier)
-      return unless Collection.properties.keys.include?(work_identifier)
-      Collection.where(
-        work_identifier => collection_identifier
-      ).detect { |m| m.send(work_identifier).include?(collection_identifier) }
+      Bulkrax.object_factory.search_by_property(
+        klass: Collection,
+        value: collection_identifier,
+        search_field: work_identifier,
+        name_field: work_identifier,
+        verify_property: true
+      )
     end
   end
 end

--- a/spec/bulkrax/entry_spec_helper_spec.rb
+++ b/spec/bulkrax/entry_spec_helper_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Bulkrax::EntrySpecHelper do
       it { is_expected.to be_a(Bulkrax::OaiDcEntry) }
 
       it "parses metadata" do
-        allow(Collection).to receive(:where).and_return([])
+        allow(Bulkrax.object_factory).to receive(:search_by_property).and_return(nil)
         entry.build_metadata
 
         expect(entry.factory_class).to eq(Work)

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -6,6 +6,9 @@ require 'rails_helper'
 module Bulkrax
   RSpec.describe CsvEntry, type: :model do
     describe '.read_data' do
+      before do
+        allow(Bulkrax.object_factory).to receive(:search_by_property).and_return(nil)
+      end
       it 'handles mixed case and periods for column names' do
         path = File.expand_path('../../fixtures/csv/mixed-case.csv', __dir__)
         data = described_class.read_data(path)

--- a/spec/models/bulkrax/entry_spec.rb
+++ b/spec/models/bulkrax/entry_spec.rb
@@ -10,7 +10,7 @@ module Bulkrax
       let(:collection) { FactoryBot.build(:collection) }
 
       before do
-        allow(Collection).to receive(:where).and_return([collection])
+        allow(Bulkrax.object_factory).to receive(:search_by_property).and_return(collection)
       end
 
       context '.mapping' do
@@ -22,9 +22,6 @@ module Bulkrax
       context '.find_collection' do
         it 'finds the collection' do
           expect(subject.find_collection('commons.ptsem.edu_MyCollection')).to eq(collection)
-        end
-        it 'does find the collection with a partial match' do
-          expect(subject.find_collection('MyCollection')).not_to eq(collection)
         end
       end
 

--- a/spec/models/bulkrax/oai_entry_spec.rb
+++ b/spec/models/bulkrax/oai_entry_spec.rb
@@ -61,12 +61,12 @@ module Bulkrax
       end
 
       it 'expects only one collection' do
-        allow(Collection).to receive(:where).and_return([collection])
+        allow(Bulkrax.object_factory).to receive(:search_by_property).and_return(collection)
         entry.find_collection_ids
         expect(entry.collection_ids.length).to eq(1)
       end
       it 'fails if there is no collection' do
-        allow(Collection).to receive(:where).and_return([])
+        allow(Bulkrax.object_factory).to receive(:search_by_property).and_return(nil)
         entry.find_collection_ids
         expect(entry.collection_ids.length).to eq(0)
       end

--- a/spec/models/bulkrax/object_factory_spec.rb
+++ b/spec/models/bulkrax/object_factory_spec.rb
@@ -11,6 +11,20 @@ module Bulkrax
   RSpec.describe ObjectFactory do
     subject(:object_factory) { build(:object_factory) }
 
+    describe '.search_by_property' do
+      let(:collections) do
+        [
+          FactoryBot.build(:collection, title: ["Specific Title"]),
+          FactoryBot.build(:collection, title: ["Title"])
+        ]
+      end
+      let(:klass) { double(where: collections) }
+
+      it 'does find the collection with a partial match' do
+        collection = described_class.search_by_property(value: "Title", field: :title, klass: klass)
+        expect(collection.title).to eq(["Title"])
+      end
+    end
     describe 'is capable of looking up records dynamically' do
       include_examples 'dynamic record lookup'
     end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2024_02_09_070952) do
     t.integer "import_attempts", default: 0
     t.string "status_message", default: "Pending"
     t.index ["identifier", "importerexporter_id", "importerexporter_type"], name: "bulkrax_identifier_idx"
+    t.index ["identifier"], name: "index_bulkrax_entries_on_identifier"
     t.index ["importerexporter_id", "importerexporter_type"], name: "bulkrax_entries_importerexporter_idx"
     t.index ["type"], name: "index_bulkrax_entries_on_type"
   end
@@ -646,4 +647,14 @@ ActiveRecord::Schema.define(version: 2024_02_09_070952) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "bulkrax_exporter_runs", "bulkrax_exporters", column: "exporter_id"
+  add_foreign_key "bulkrax_importer_runs", "bulkrax_importers", column: "importer_id"
+  add_foreign_key "bulkrax_pending_relationships", "bulkrax_importer_runs", column: "importer_run_id"
+  add_foreign_key "collection_type_participants", "hyrax_collection_types"
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id"
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id"
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id"
+  add_foreign_key "permission_template_accesses", "permission_templates"
+  add_foreign_key "uploaded_files", "users"
 end


### PR DESCRIPTION
## ♻️ Extract Hyrax.object_factory.search_by_property

32c057ce02b9d4ed26f391ebc06642fb491ac536

There is a duplication of this logic elsewhere, but I first wanted to
extract common logic then begin extracting full replacement and
conforming object interface for Valkyrie.

## ♻️ Extract method for Valkyrization

e942f6257361ba61d047887dcfb8bf7fde8908ab

We cannot directly query the class.  But must instead favor the
object_factory.
