### PR TITLE
🎁 Change glyphicon to font awesome

### DIFF
--- a/app/assets/javascripts/bulkrax/datatables.js
+++ b/app/assets/javascripts/bulkrax/datatables.js
@@ -133,7 +133,7 @@ function refreshLink() {
   refreshLink.onclick = function() {
     this.api().ajax.reload(null, false)
   }.bind(this)
-  refreshLink.classList.value = 'glyphicon glyphicon-refresh'
+  refreshLink.classList.value = 'fa fa-refresh'
   refreshLink.style.marginLeft = '10px'
   document.querySelector('div.dataTables_filter').firstChild.append(refreshLink)
 }

--- a/app/controllers/concerns/bulkrax/datatables_behavior.rb
+++ b/app/controllers/concerns/bulkrax/datatables_behavior.rb
@@ -145,37 +145,37 @@ module Bulkrax
 
     def entry_util_links(e, item)
       links = []
-      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-info-sign"></span>'), view_context.item_entry_path(item, e))
-      links << "<a class='glyphicon glyphicon-repeat' data-toggle='modal' data-target='#bulkraxItemModal' data-entry-id='#{e.id}'></a>" if view_context.an_importer?(item)
-      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-trash"></span>'), view_context.item_entry_path(item, e), method: :delete, data: { confirm: 'This will delete the entry and any work associated with it. Are you sure?' })
+      links << view_context.link_to(view_context.raw('<span class="fa fa-info-circle"></span>'), view_context.item_entry_path(item, e))
+      links << "<a class='fa fa-repeat' data-toggle='modal' data-target='#bulkraxItemModal' data-entry-id='#{e.id}'></a>" if view_context.an_importer?(item)
+      links << view_context.link_to(view_context.raw('<span class="fa fa-trash"></span>'), view_context.item_entry_path(item, e), method: :delete, data: { confirm: 'This will delete the entry and any work associated with it. Are you sure?' })
       links.join(" ")
     end
 
     def status_message_for(e)
       if e.status_message == "Complete"
-        "<td><span class='glyphicon glyphicon-ok' style='color: green;'></span> #{e.status_message}</td>"
+        "<td><span class='fa fa-check' style='color: green;'></span> #{e.status_message}</td>"
       elsif e.status_message == "Pending"
-        "<td><span class='glyphicon glyphicon-option-horizontal' style='color: blue;'></span> #{e.status_message}</td>"
+        "<td><span class='fa fa-ellipsis-h' style='color: blue;'></span> #{e.status_message}</td>"
       elsif e.status_message == "Skipped"
-        "<td><span class='glyphicon glyphicon-step-forward' style='color: yellow;'></span> #{e.status_message}</td>"
+        "<td><span class='fa fa-step-forward' style='color: yellow;'></span> #{e.status_message}</td>"
       else
-        "<td><span class='glyphicon glyphicon-remove' style='color: #{e.status == 'Deleted' ? 'green' : 'red'};'></span> #{e.status_message}</td>"
+        "<td><span class='fa fa-remove' style='color: #{e.status == 'Deleted' ? 'green' : 'red'};'></span> #{e.status_message}</td>"
       end
     end
 
     def importer_util_links(i)
       links = []
-      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-info-sign"></span>'), importer_path(i))
-      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_importer_path(i))
-      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
+      links << view_context.link_to(view_context.raw('<span class="fa fa-info-circle"></span>'), importer_path(i))
+      links << view_context.link_to(view_context.raw('<span class="fa fa-pencil"></span>'), edit_importer_path(i))
+      links << view_context.link_to(view_context.raw('<span class="fa fa-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
       links.join(" ")
     end
 
     def exporter_util_links(i)
       links = []
-      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-info-sign"></span>'), exporter_path(i))
-      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-pencil"></span>'), edit_exporter_path(i), data: { turbolinks: false })
-      links << view_context.link_to(view_context.raw('<span class="glyphicon glyphicon-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
+      links << view_context.link_to(view_context.raw('<span class="fa fa-info-circle"></span>'), exporter_path(i))
+      links << view_context.link_to(view_context.raw('<span class="fa fa-pencil"></span>'), edit_exporter_path(i), data: { turbolinks: false })
+      links << view_context.link_to(view_context.raw('<span class="fa fa-remove"></span>'), i, method: :delete, data: { confirm: 'Are you sure?' })
       links.join(" ")
     end
 

--- a/app/views/bulkrax/entries/_parsed_metadata.html.erb
+++ b/app/views/bulkrax/entries/_parsed_metadata.html.erb
@@ -5,7 +5,7 @@
         Parsed Metadata:
       </a>
       <a role="button" data-toggle="collapse" data-target="#parsed-metadata-show" aria-expanded="true" aria-controls="parsed-metadata-show">
-        <div class="accordion-icon glyphicon glyphicon-remove-circle" aria-hidden="true"></div>
+        <div class="accordion-icon fa fa-times-circle" aria-hidden="true"></div>
       </a>
     </div>
     <div id="parsed-metadata-show" class="accordion-collapse collapse" role="tabpanel" aria-labelledby="parsed-metadata-show">

--- a/app/views/bulkrax/entries/_raw_metadata.html.erb
+++ b/app/views/bulkrax/entries/_raw_metadata.html.erb
@@ -5,7 +5,7 @@
         Raw Metadata:
       </a>
       <a role="button" data-toggle="collapse" data-target="#raw-metadata-show" aria-expanded="true" aria-controls="raw-metadata-show">
-        <div class="accordion-icon glyphicon glyphicon-remove-circle" aria-hidden="true"></div>
+        <div class="accordion-icon fa fa-times-circle" aria-hidden="true"></div>
       </a>
     </div>
     <div id="raw-metadata-show" class="accordion-collapse collapse" role="tabpanel" aria-labelledby="raw-metadata-show">

--- a/app/views/bulkrax/importers/_browse_everything.html.erb
+++ b/app/views/bulkrax/importers/_browse_everything.html.erb
@@ -3,10 +3,10 @@
 	f = "#{form.lookup_action}_importer"
 	f = "#{f}_#{@importer.id}" unless @importer.new_record?
 %>
-<div id='cloud-files'> 
+<div id='cloud-files'>
 	<button type="button" data-toggle="browse-everything" data-route="<%=browse_everything_engine.root_path%>"
 		data-target="#<%= f %>" class="btn btn-primary" id="browse">
-		<span class="glyphicon glyphicon-plus"></span>
+		<span class="fa fa-plus"></span>
 		Add Cloud Files
 	</button>
 </div>

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -45,7 +45,7 @@
           Parser fields:
         </a>
         <a role="button" data-toggle="collapse" data-target="#parser-fields-importer-show" aria-expanded="true" aria-controls="parser-fields-importer-show">
-          <div class="accordion-icon glyphicon glyphicon-remove-circle" aria-hidden="true"></div>
+          <div class="accordion-icon fa fa-times-circle" aria-hidden="true"></div>
         </a>
       </div>
       <div id="parser-fields-importer-show" class="accordion-collapse collapse" role="tabpanel" aria-labelledby="parser-fields-heading">

--- a/app/views/bulkrax/importers/upload_corrected_entries.html.erb
+++ b/app/views/bulkrax/importers/upload_corrected_entries.html.erb
@@ -7,7 +7,7 @@
     <p>
     Upload <b>only</b> the corrected entries for the <b><%= @importer.name %></b> importer. To export failed entries for correction,
     <%= link_to importer_export_errors_path(@importer.id) do %>
-      click here <span class='glyphicon glyphicon-download-alt'></span>
+      click here <span class='fa fa-download'></span>
     <% end %>
     </p>
     <p>Only CSV files are allowed.</p>
@@ -18,7 +18,7 @@
           <div class='fileupload-buttonbar hide-required-tag'>
             <%= fi.input 'file',
               as: :file,
-              label: "<span class='glyphicon glyphicon-plus'></span><span> Add file...</span>".html_safe,
+              label: "<span class='fa fa-plus'></span><span> Add file...</span>".html_safe,
               label_html: {
                 class: 'btn btn-success'
               },

--- a/app/views/bulkrax/shared/_bulkrax_errors.html.erb
+++ b/app/views/bulkrax/shared/_bulkrax_errors.html.erb
@@ -5,7 +5,7 @@
         Errors:
       </a>
       <a role="button" data-toggle="collapse" data-target="#error-trace-show" aria-expanded="true" aria-controls="error-trace-show">
-        <div class="accordion-icon glyphicon glyphicon-remove-circle" aria-hidden="true"></div>
+        <div class="accordion-icon fa fa-times-circle" aria-hidden="true"></div>
       </a>
     </div>
     <div id="error-trace-show" class="accordion-collapse collapse" role="tabpanel" aria-labelledby="error-trace-show">

--- a/app/views/bulkrax/shared/_bulkrax_field_mapping.html.erb
+++ b/app/views/bulkrax/shared/_bulkrax_field_mapping.html.erb
@@ -5,7 +5,7 @@
         <strong>Field mapping:</strong>
       </a>
       <a role="button" data-toggle="collapse" data-target="#field-mapping-show" aria-expanded="true" aria-controls="field-mapping-show">
-        <div class="accordion-icon glyphicon glyphicon-remove-circle" aria-hidden="true"></div>
+        <div class="accordion-icon fa fa-times-circle" aria-hidden="true"></div>
       </a>
     </div>
     <div id="field-mapping-show" class="accordion-collapse collapse" role="tabpanel" aria-labelledby="field-mapping-show">

--- a/spec/controllers/concerns/bulkrax/datatables_behavior_spec.rb
+++ b/spec/controllers/concerns/bulkrax/datatables_behavior_spec.rb
@@ -105,9 +105,9 @@ RSpec.describe Bulkrax::ImportersController, type: :controller do
       get :index
       result = controller.entry_util_links(entry, item)
       expect(result).to be_a(String)
-      expect(result).to include('glyphicon-info-sign')
-      expect(result).to include('glyphicon-repeat')
-      expect(result).to include('glyphicon-trash')
+      expect(result).to include('fa-info-circle')
+      expect(result).to include('fa-repeat')
+      expect(result).to include('fa-trash')
     end
 
     it 'includes a link to the entry' do
@@ -131,28 +131,28 @@ RSpec.describe Bulkrax::ImportersController, type: :controller do
       entry = FactoryBot.create(:bulkrax_entry, importerexporter: item, status_message: 'Complete')
       get :index
       result = controller.status_message_for(entry)
-      expect(result).to include('<span class=\'glyphicon glyphicon-ok\' style=\'color: green;\'></span> Complete')
+      expect(result).to include('<span class=\'fa fa-check\' style=\'color: green;\'></span> Complete')
     end
 
     it 'returns a string of HTML with a blue "horizontal ellipsis" icon when status_message is "Pending"' do
       entry = FactoryBot.create(:bulkrax_entry, importerexporter: item, status_message: 'Pending')
       get :index
       result = controller.status_message_for(entry)
-      expect(result).to include('<span class=\'glyphicon glyphicon-option-horizontal\' style=\'color: blue;\'></span> Pending')
+      expect(result).to include('<span class=\'fa fa-ellipsis-h\' style=\'color: blue;\'></span> Pending')
     end
 
     it 'returns a string of HTML with a red "remove" icon when status_message is neither "Complete" nor "Pending"' do
       entry = FactoryBot.create(:bulkrax_entry, importerexporter: item, status_message: 'Error')
       get :index
       result = controller.status_message_for(entry)
-      expect(result).to include('<span class=\'glyphicon glyphicon-remove\' style=\'color: red;\'></span> Error')
+      expect(result).to include('<span class=\'fa fa-remove\' style=\'color: red;\'></span> Error')
     end
 
     it 'returns a string of HTML with a red "remove" icon when status_message is "Deleted"' do
       entry = FactoryBot.create(:bulkrax_entry, importerexporter: item, status_message: 'Deleted')
       get :index
       result = controller.status_message_for(entry)
-      expect(result).to include('<span class=\'glyphicon glyphicon-remove\' style=\'color: red;\'></span> Deleted')
+      expect(result).to include('<span class=\'fa fa-remove\' style=\'color: red;\'></span> Deleted')
     end
   end
 end


### PR DESCRIPTION
Hyrax 4+ applications use font awesome and not glyphicon. This commit will convert all glyphicon to font awesome. 
 Previous versions of Hyrax use both glyphicon and font awesome so this should be backwards compatible.

<img width="1469" alt="image" src="https://github.com/samvera/bulkrax/assets/19597776/58ed3f07-4d2e-447a-a5e1-a1da68f90a4a">

<img width="1443" alt="image" src="https://github.com/samvera/bulkrax/assets/19597776/40642d4c-fe37-48b0-91b5-5549163c1e7f">
