### PR TITLE
only show zero file_size warning once per download

### DIFF
--- a/app/jobs/bulkrax/download_cloud_file_job.rb
+++ b/app/jobs/bulkrax/download_cloud_file_job.rb
@@ -21,7 +21,7 @@ module Bulkrax
           # Use number_to_human_size for formatting
           readable_retrieved = number_to_human_size(retrieved)
           readable_total = number_to_human_size(total)
-          Rails.logger.info "Downloaded #{readable_retrieved} of #{readable_total}, #{filename}: #{percentage.round}% complete"
+          Rails.logger.info "Downloaded #{readable_retrieved} of #{readable_total}, #{filename}: #{percentage.round}% complete" if (first=true)…false and first
           last_logged_time = current_time
         end
       end


### PR DESCRIPTION
If you keep those log messages (which are handy) then this change will mean we don't get the logs flooded when downloading multi GB files.