### PR TITLE
Index :bulkrax_identifier metadata in :orm_resources

### DIFF
--- a/db/migrate/20240307053156_add_index_to_metadata_bulkrax_identifier.rb
+++ b/db/migrate/20240307053156_add_index_to_metadata_bulkrax_identifier.rb
@@ -1,0 +1,18 @@
+class AddIndexToMetadataBulkraxIdentifier < ActiveRecord::Migration[6.1]
+  def up
+    return unless table_exists?(:orm_resources)
+    return if index_exists?(:orm_resources, "(((metadata -> 'bulkrax_identifier'::text) ->> 0))", name: 'index_on_bulkrax_identifier')
+
+    # This creates an expression index on the first element of the bulkrax_identifier array
+    add_index :orm_resources,
+              "(metadata -> 'bulkrax_identifier' ->> 0)",
+              name: 'index_on_bulkrax_identifier',
+              where: "metadata -> 'bulkrax_identifier' IS NOT NULL"
+  end
+
+  def down
+    return unless table_exists?(:orm_resources)
+
+    remove_index :orm_resources, name: 'index_on_bulkrax_identifier'
+  end
+end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -101,8 +101,6 @@ ActiveRecord::Schema.define(version: 2024_02_09_070952) do
     t.integer "total_file_set_entries", default: 0
     t.integer "processed_works", default: 0
     t.integer "failed_works", default: 0
-    t.integer "processed_children", default: 0
-    t.integer "failed_children", default: 0
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 
@@ -646,4 +644,14 @@ ActiveRecord::Schema.define(version: 2024_02_09_070952) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "bulkrax_exporter_runs", "bulkrax_exporters", column: "exporter_id"
+  add_foreign_key "bulkrax_importer_runs", "bulkrax_importers", column: "importer_id"
+  add_foreign_key "bulkrax_pending_relationships", "bulkrax_importer_runs", column: "importer_run_id"
+  add_foreign_key "collection_type_participants", "hyrax_collection_types"
+  add_foreign_key "curation_concerns_operations", "users"
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", column: "conversation_id"
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", column: "conversation_id"
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", column: "notification_id"
+  add_foreign_key "permission_template_accesses", "permission_templates"
+  add_foreign_key "uploaded_files", "users"
 end


### PR DESCRIPTION
This significantly speeds up queries like [this one](https://github.com/WGBH-MLA/ams/blob/c27625be06778f958cde0ffd7af802b69def4c78/app/services/hyrax/custom_queries/find_by_bulkrax_identifier.rb#L25-L30). 

Originally implemented by @orangewolf in GBH AMS. 