### PR TITLE
I951 false object bug

### DIFF
--- a/app/concerns/loggable.rb
+++ b/app/concerns/loggable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Loggable
+  extend ActiveSupport::Concern
+
+  def log_created(obj)
+    log_action('Created', obj)
+  end
+
+  def log_updated(obj)
+    log_action('Updated', obj)
+  end
+
+  def log_deleted_fs(obj)
+    msg = "Deleted All Files from #{obj.id}"
+    Rails.logger.info("#{msg} (#{Array(obj.attributes[work_identifier]).first})")
+  end
+
+  private
+
+  def log_action(action, obj)
+    msg = "#{action} #{obj.class.model_name.human} #{obj.id}"
+    Rails.logger.info("#{msg} (#{Array(obj.attributes[work_identifier]).first})")
+  end
+end

--- a/app/factories/bulkrax/object_factory_interface.rb
+++ b/app/factories/bulkrax/object_factory_interface.rb
@@ -20,6 +20,7 @@ module Bulkrax
   class ObjectFactoryInterface
     extend ActiveModel::Callbacks
     include DynamicRecordLookup
+    include Loggable
 
     # We're inheriting from an ActiveRecord exception as that is something we
     # know will be here; and something that the main_app will be expect to be
@@ -402,21 +403,6 @@ module Bulkrax
     def add_user_to_collection_permissions(*args)
       arguments = args.first
       self.class.add_user_to_collection_permissions(**arguments)
-    end
-
-    def log_created(obj)
-      msg = "Created #{klass.model_name.human} #{obj.id}"
-      Rails.logger.info("#{msg} (#{Array(attributes[work_identifier]).first})")
-    end
-
-    def log_updated(obj)
-      msg = "Updated #{klass.model_name.human} #{obj.id}"
-      Rails.logger.info("#{msg} (#{Array(attributes[work_identifier]).first})")
-    end
-
-    def log_deleted_fs(obj)
-      msg = "Deleted All Files from #{obj.id}"
-      Rails.logger.info("#{msg} (#{Array(attributes[work_identifier]).first})")
     end
 
     private

--- a/app/models/concerns/bulkrax/file_factory.rb
+++ b/app/models/concerns/bulkrax/file_factory.rb
@@ -155,6 +155,8 @@ module Bulkrax
       end
 
       def ordered_file_sets
+        return [] unless object.present?
+
         Bulkrax.object_factory.ordered_file_sets_for(object)
       end
 

--- a/app/models/concerns/bulkrax/file_factory.rb
+++ b/app/models/concerns/bulkrax/file_factory.rb
@@ -32,6 +32,8 @@ module Bulkrax
     end
 
     class InnerWorkings
+      include Loggable
+
       def initialize(object_factory:)
         @object_factory = object_factory
       end
@@ -155,7 +157,7 @@ module Bulkrax
       end
 
       def ordered_file_sets
-        return [] unless object.present?
+        return [] if object.blank?
 
         Bulkrax.object_factory.ordered_file_sets_for(object)
       end


### PR DESCRIPTION
# Summary

ActiveFedora based applications were unable to import works when they upgraded to v8.0.0 (the first Bulkrax version that supports valkyrie) 

Issue: 
- https://github.com/samvera/bulkrax/issues/951

## BEFORE
![image (61)](https://github.com/samvera/bulkrax/assets/10081604/d75e368e-9868-447b-b5ce-b0b8947ec1c8)


## AFTER 

![Screenshot 2024-04-19 at 16-51-20 Show Entry __ Hyku Commons](https://github.com/samvera/bulkrax/assets/10081604/b7b9a869-5e96-4990-beb1-3bc904fd1af3)

![Screenshot 2024-04-19 at 16-51-31 An Image](https://github.com/samvera/bulkrax/assets/10081604/9a10ec8a-cf11-4f97-888b-959eab00e2a0)

## Sample testing files
[af-embargo-test.zip](https://github.com/samvera/bulkrax/files/15046287/af-embargo-test.zip)

