### PR TITLE
🐛 Fix FileSet csv rows for AF imports

### DIFF
--- a/app/jobs/bulkrax/import_file_set_job.rb
+++ b/app/jobs/bulkrax/import_file_set_job.rb
@@ -16,7 +16,12 @@ module Bulkrax
       # e.g. "parents" or "parents_1"
       parent_identifier = (entry.raw_metadata[entry.related_parents_raw_mapping] || entry.raw_metadata["#{entry.related_parents_raw_mapping}_1"])&.strip
 
-      validate_parent!(parent_identifier)
+      begin
+        validate_parent!(parent_identifier)
+      rescue MissingParentError => e
+        handle_retry(entry, importer_run_id, e)
+        return
+      end
 
       entry.build
       if entry.succeeded?
@@ -32,17 +37,6 @@ module Bulkrax
       entry.save!
       entry.importer.current_run = ImporterRun.find(importer_run_id)
       entry.importer.record_status
-
-    rescue MissingParentError => e
-      # try waiting for the parent record to be created
-      entry.import_attempts += 1
-      entry.save!
-      if entry.import_attempts < 5
-        ImportFileSetJob.set(wait: (entry.import_attempts + 1).minutes).perform_later(entry_id, importer_run_id)
-      else
-        ImporterRun.decrement_counter(:enqueued_records, importer_run_id) # rubocop:disable Rails/SkipsModelValidations
-        entry.set_status_info(e)
-      end
     end
 
     private
@@ -54,12 +48,7 @@ module Bulkrax
       return if parent_identifier.blank?
 
       find_parent_record(parent_identifier)
-      check_parent_exists!(parent_identifier)
       check_parent_is_a_work!(parent_identifier)
-    end
-
-    def check_parent_exists!(parent_identifier)
-      raise MissingParentError, %(Unable to find a record with the identifier "#{parent_identifier}") if parent_record.nil?
     end
 
     def check_parent_is_a_work!(parent_identifier)
@@ -72,6 +61,18 @@ module Bulkrax
 
     def find_parent_record(parent_identifier)
       _, @parent_record = find_record(parent_identifier, importer_run_id)
+      raise MissingParentError, %(Unable to find a record with the identifier "#{parent_identifier}") unless parent_record
+    end
+
+    def handle_retry(entry, importer_run_id, e)
+      entry.import_attempts += 1
+      entry.save!
+      if entry.import_attempts < 5
+        ImportFileSetJob.set(wait: (entry.import_attempts + 1).minutes).perform_later(entry.id, importer_run_id)
+      else
+        ImporterRun.decrement_counter(:enqueued_records, importer_run_id) # rubocop:disable Rails/SkipsModelValidations
+        entry.set_status_info(e)
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary

This commit will fix the functionality for adding a FileSet row in the CSV to add additional metadata to FileSets.  The problem was located in `Bulkrax::ObjectFactory#create_file_set`.  When it tries to find a record, it actually comes back as a `FalseClass` because of the new logic introduced recently which breaks further down.  If we add raise an error in our `Bulkrax::ImportFileSetJob#find_parent_record` which is at a higher point than before, then we can requeue the job and check again. If the parent record is created by then, we will execute the rest of the job.

Issue: 
- https://github.com/scientist-softserv/hykuup_knapsack/issues/216

# Screenshots

![image](https://github.com/samvera/bulkrax/assets/19597776/c0028088-e8ec-44fb-8d1f-d067f1632d37)

![image](https://github.com/samvera/bulkrax/assets/19597776/7e97631c-4cf3-4186-8727-559ccad9c707)

# Testing Instructions

This fix was made in the PALs repo, here is the CSV used:
[pals-with-file-row.zip](https://github.com/samvera/bulkrax/files/15276997/pals-with-file-row.zip)
