### PR TITLE
add support for downloading the original file

### DIFF
--- a/app/controllers/bulkrax/importers_controller.rb
+++ b/app/controllers/bulkrax/importers_controller.rb
@@ -13,7 +13,7 @@ module Bulkrax
     before_action :token_authenticate!, if: -> { api_request? }, only: [:create, :update, :delete]
     before_action :authenticate_user!, unless: -> { api_request? }
     before_action :check_permissions
-    before_action :set_importer, only: [:show, :entry_table, :edit, :update, :destroy]
+    before_action :set_importer, only: [:show, :entry_table, :edit, :update, :destroy, :original_file]
     with_themed_layout 'dashboard' if defined?(::Hyrax)
 
     # GET /importers
@@ -198,6 +198,14 @@ module Bulkrax
         render json: { base_url: params[:base_url], sets: @sets }
       else
         render json: { base_url: params[:base_url], error: "unable to pull data from #{params[:base_url]}" }
+      end
+    end
+
+    def original_file
+      if @importer.original_file?
+        send_file @importer.original_file
+      else
+        redirect_to @importer, alert: 'Importer does not support file re-download or the imported file is not found on the server.'
       end
     end
 

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -149,6 +149,14 @@ module Bulkrax
       @seen ||= {}
     end
 
+    def original_file?
+      File.exists?(self.parser_fields['import_file_path'])
+    end
+
+    def original_file
+      self.parser_fields['import_file_path'] if original_file?
+    end
+
     def replace_files
       self.parser_fields['replace_files']
     end

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -150,7 +150,7 @@ module Bulkrax
     end
 
     def original_file?
-      File.exists?(self.parser_fields['import_file_path'])
+      File.exist?(self.parser_fields['import_file_path'])
     end
 
     def original_file

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -1,12 +1,12 @@
 <div class="col-xs-12 main-header">
   <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Importer: <%= @importer.name %></h1>
-
-  <% if @importer.failed_entries? %>
-    <div class="pull-right">
+  <div class="pull-right">
+    <%= link_to 'Download Original File', importer_original_file_path(@importer.id), class: 'btn btn-primary', data: { turbolinks: false } if @importer.original_file %>
+    <% if @importer.failed_entries? %>
       <%= link_to 'Export Errored Entries', importer_export_errors_path(@importer.id), class: 'btn btn-primary', data: { turbolinks: false }%>
       <%= link_to 'Upload Corrected Entries', importer_upload_corrected_entries_path(@importer.id), class: 'btn btn-primary' if @importer.parser.is_a?(Bulkrax::CsvParser) %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>
 <div class="panel panel-default bulkrax-align-text">
   <div class="panel-body">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Bulkrax::Engine.routes.draw do
   end
   resources :importers do
     put :continue
+    get :original_file
     get :entry_table
     get :export_errors
     collection do


### PR DESCRIPTION
It can be useful to be able to download the file that was originally uploaded for an import. It won't work in all cases (such as OAI) but it will work in most cases.

<img width="1728" alt="Screenshot 2024-05-23 at 22 24 30" src="https://github.com/samvera/bulkrax/assets/1054448/2eb59347-4c99-43cf-95b6-b6a08af172ed">
<img width="1728" alt="Screenshot 2024-05-23 at 22 24 23" src="https://github.com/samvera/bulkrax/assets/1054448/df5bef56-c05c-4180-ba63-bf28a8c12237">
