### PR TITLE
Bump version for minor release

### DIFF
--- a/lib/bulkrax/version.rb
+++ b/lib/bulkrax/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bulkrax
-  VERSION = '8.0.0'
+  VERSION = '8.1.0'
 end


### PR DESCRIPTION
Cutting a 8.1.0 release which contains bug fixes and the embargo support feature ...

d8f9b85 — Downgraded ActiveRecord method version from 6.1 to 5.2 - Fixes #948 (#949) Dan Kerchner, (2024-05-28)  (HEAD -> main, origin/main, origin/HEAD)

0de8ee0 — 🐛 Fix FileSet csv rows for AF imports (#954) Kirk Wang, (2024-05-10) 

bf7bc5c — :bug: [I951] false object import bug (#952) Shana Moore, (2024-04-22) 

855ce39 — I1010 embargo lease support (#950) Shana Moore, (2024-04-17) 