### PR TITLE
fix a memory leak when copying large files by using the hyrax uploader

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -250,7 +250,7 @@ module Bulkrax
 
     def file_set_operation_for(user:)
       Hyrax::Operation.create!(user: user,
-        operation_type: "Attach Remote File")
+                               operation_type: "Attach Remote File")
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -245,7 +245,7 @@ module Bulkrax
       actor.file_set.import_url = remote_file['url']
       auth_header = remote_file.fetch('auth_header', {})
 
-      ImportUrlJob.perform_now(actor.file_set, operation_for(user: @user), auth_header)
+      ImportUrlJob.perform_now(actor.file_set, file_set_operation_for(user: @user), auth_header)
     end
 
     def file_set_operation_for(user:)

--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -228,19 +228,19 @@ module Bulkrax
       actor.create_metadata(attrs)
       actor.create_content(uploaded_file) if uploaded_file
       actor.attach_to_work(work, attrs)
-      handle_remote_file(remote_file: remote_file, actor: actor, update: false) if remote_file
+      handle_remote_file(remote_file: remote_file, actor: actor) if remote_file
     end
 
     def update_file_set(attrs)
       file_set_attrs = attrs.slice(*object.attributes.keys)
       actor = ::Hyrax::Actors::FileSetActor.new(object, @user)
       attrs['remote_files']&.each do |remote_file|
-        handle_remote_file(remote_file: remote_file, actor: actor, update: true)
+        handle_remote_file(remote_file: remote_file, actor: actor)
       end
       actor.update_metadata(file_set_attrs)
     end
 
-    def handle_remote_file(remote_file:, actor:, update: false)
+    def handle_remote_file(remote_file:, actor:)
       actor.file_set.label = remote_file['file_name']
       actor.file_set.import_url = remote_file['url']
       auth_header = remote_file.fetch('auth_header', {})


### PR DESCRIPTION
instead of a custom one