### PR TITLE
i84 - update visibility label and help text

### DIFF
--- a/app/views/bulkrax/importers/_csv_fields.html.erb
+++ b/app/views/bulkrax/importers/_csv_fields.html.erb
@@ -1,13 +1,15 @@
 <div class='csv_fields'>
 
   <%= fi.input :visibility,
+    label: 'Default Visibility',
     collection: [
       ['Public', 'open'],
       ['Private', 'restricted'],
       ['Institution', 'authenticated']
     ],
     selected: importer.parser_fields['visibility'] || 'open',
-    input_html: { class: 'form-control' }
+    input_html: { class: 'form-control' },
+    hint: 'If your CSV includes the visibility field, it will override the default setting.'
   %>
 
   <% if defined?(::Hyrax) %>


### PR DESCRIPTION
This was contributed back per PALNI PALCI. Since it's possible to override whatever setting the user selects at the form level, help text is provided. If the visibility is declared at the CSV level, the visibility selected at the form level will be ignored.

Issue:
- https://github.com/scientist-softserv/palni_palci_knapsack/issues/84

## BEFORE

![image](https://github.com/samvera/bulkrax/assets/10081604/124d6c4b-c590-4381-a456-f780cb1cb0d9)




## AFTER

![image](https://github.com/samvera/bulkrax/assets/10081604/346d8a20-a7fb-40a8-908a-eb3364161858)

