### PR TITLE
i91 - saving nil object caused errors

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -225,10 +225,10 @@ module Bulkrax
     private
 
     def apply_depositor_metadata
-      return if object.depositor.present?
+      return if @object.depositor.present?
 
-      object.depositor = @user.email
-      object = Hyrax.persister.save(resource: object)
+      @object.depositor = @user.email
+      object = Hyrax.persister.save(resource: @object)
       self.class.publish(event: "object.metadata.updated", object: object, user: @user)
       object
     end


### PR DESCRIPTION
object equals nil here. but @object returned what we were looking for. Update code so that we save @object instead of saving nil, which rightfully raised errors.

Related issue:
- https://github.com/scientist-softserv/palni_palci_knapsack/issues/91

Tested from Hyku to verify this works: 

![image](https://github.com/samvera/bulkrax/assets/10081604/ef802323-5d0b-4e01-a49e-ae1745a3c017)

[split-embargo-hyku.zip](https://github.com/user-attachments/files/15903184/split-embargo-hyku.zip)

