### PR TITLE
🐛 bom bug fix

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -21,7 +21,7 @@ module Bulkrax
       options = {
         headers: true,
         header_converters: ->(h) { h.to_s.strip.to_sym },
-        encoding: 'utf-8'
+        encoding: 'bom|utf-8'
       }.merge(csv_read_data_options)
 
       results = CSV.read(path, **options)


### PR DESCRIPTION
Issue:
- https://github.com/scientist-softserv/adventist_knapsack/issues/680

The client would import CSVs that had identifier columns, but the importer would still fail with "Missing at least one required element, missing element(s) are: identifier issue when the CSV contains the identifier column."

This commit utitlizes the BOM method, previously created to normalize data, and adds bom support for reading CSVs.