### PR TITLE
:bug: Refactor: Fix file path access to prevent error

### DIFF
--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -149,12 +149,16 @@ module Bulkrax
       @seen ||= {}
     end
 
+    def import_file_path
+      self.parser_fields['import_file_path']
+    end
+
     def original_file?
-      File.exist?(self.parser_fields['import_file_path'])
+      import_file_path && File.exist?(import_file_path)
     end
 
     def original_file
-      self.parser_fields['import_file_path'] if original_file?
+      import_file_path if original_file?
     end
 
     def replace_files


### PR DESCRIPTION
# Summary

When testing the OAI importer on Adventist valkyrie, we received the following error. The error was caused because oai imports from a feed, so no original file exists. When checking, instead of returning false it returned nil, and thus caused a TypeError. 

related: 
- https://github.com/scientist-softserv/adventist_knapsack/issues/723

# Screenshots / Video

## BEFORE

![Screenshot 2024-08-02 at 14-37-00 Action Controller Exception caught](https://github.com/user-attachments/assets/1fc6c2b9-b36a-4766-9845-c50ef58245ed)

## AFTER
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/cc5ef765-088a-44c0-a9d0-4e525cf16937">



# Expected Behavior
The site will not break when an original file doesn't exist.

# Notes

## :bug: Refactor: Fix file path access to prevent error

970ad45906b1db6f02f19679f723318da4c22418

- Centralized the import_file_path logic into a separate method
- Resolved TypeError caused by nil values when checking file existence
- Improved code readability and maintainability
