### PR TITLE
:broom: expands the ability to upload remote_files for valkyrie

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -252,14 +252,38 @@ module Bulkrax
       # NOTE: We do not add relationships here; that is part of the create
       # relationships job.
       perform_transaction_for(object: object, attrs: attrs) do
+        uploaded_files = uploaded_files_from(attrs)
+        file_set_params = file_set_params_for(uploaded_files, combined_files_with(remote_files: attrs["remote_files"]))
         transactions["change_set.create_work"]
           .with_step_args(
-            'work_resource.add_file_sets' => { uploaded_files: uploaded_files_from(attrs) },
+            'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: file_set_params },
             "change_set.set_user_as_depositor" => { user: @user },
             "work_resource.change_depositor" => { user: @user },
             'work_resource.save_acl' => { permissions_params: [attrs['visibility'] || 'open'].compact }
           )
       end
+    end
+
+    def combined_files_with(remote_files:)
+      thumbnail_url = self.attributes['thumbnail_url']
+      @combined_files ||= (thumbnail_url.present? ? remote_files + [thumbnail_url] : remote_files)
+    end
+
+    def file_set_params_for(uploaded_files, combined_files)
+      # handling remote files requires a filename to avoid the default carrierwave file name assignment.
+      # Here we tag along only the keys that are not 'url' or 'file_name' as file_set attributes.
+      # To have the additional attributes appear on the file_set, they must be:
+      # - included in the file_set_metadata.yaml
+      # - overriden in file_set_args from Hyrax::WorkUploadsHandler
+      additional_attributes = combined_files.map do |hash|
+        hash.reject { |key, _| key == 'url' || key == 'file_name' }
+      end
+
+      file_attrs = []
+      uploaded_files.each_with_index do |f, index|
+        file_attrs << ({ uploaded_file_id: f["id"].to_s, filename: combined_files[index]["file_name"] }).merge(additional_attributes[index])
+      end
+      file_attrs.compact.uniq
     end
 
     def create_collection(attrs)
@@ -329,9 +353,11 @@ module Bulkrax
 
     def update_work(attrs)
       perform_transaction_for(object: object, attrs: attrs) do
+        uploaded_files = uploaded_files_from(attrs)
+        file_set_params = file_set_params_for(uploaded_files, combined_files_with(remote_files: attrs["remote_files"]))
         transactions["change_set.update_work"]
           .with_step_args(
-            'work_resource.add_file_sets' => { uploaded_files: uploaded_files_from(attrs) },
+            'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: file_set_params },
             'work_resource.save_acl' => { permissions_params: [attrs.try('visibility') || 'open'].compact }
           )
       end
@@ -375,10 +401,7 @@ module Bulkrax
     end
 
     def uploaded_remote_files(remote_files: {})
-      thumbnail_url = self.attributes['thumbnail_url']
-      combined_files = remote_files + [thumbnail_url] if thumbnail_url.present?
-
-      combined_files.map do |r|
+      combined_files_with(remote_files:).map do |r|
         file_path = download_file(r["url"])
         next unless file_path
 

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -400,8 +400,6 @@ module Bulkrax
     end
 
     def create_uploaded_file(file_path, file_name)
-      # TODO: add migration to Hyrax::UploadedFile so that it can accept filenames
-      # ref: https://github.com/samvera/hyrax/blob/main/app/models/hyrax/uploaded_file.rb
       file = File.open(file_path)
       uploaded_file = Hyrax::UploadedFile.create(file: file, user: @user, filename: file_name)
       file.close

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -377,9 +377,9 @@ module Bulkrax
 
     def uploaded_files_from(attrs)
       uploaded_local_files(uploaded_files: attrs[:uploaded_files]) +
-      # TODO: disabled until we get s3 details 
-      # uploaded_s3_files(remote_files: attrs[:remote_files]) +
-      uploaded_remote_files(remote_files: attrs[:remote_files])
+        # TODO: disabled until we get s3 details
+        # uploaded_s3_files(remote_files: attrs[:remote_files]) +
+        uploaded_remote_files(remote_files: attrs[:remote_files])
     end
 
     def uploaded_local_files(uploaded_files: [])
@@ -401,7 +401,7 @@ module Bulkrax
     end
 
     def uploaded_remote_files(remote_files: {})
-      combined_files_with(remote_files:).map do |r|
+      combined_files_with(remote_files: remote_files).map do |r|
         file_path = download_file(r["url"])
         next unless file_path
 

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -374,7 +374,6 @@ module Bulkrax
           s3_bucket.files.get(key)
         end.compact
       else
-        # For local testing, create Hyrax::UploadedFile objects from URLs
         remote_files.map do |r|
           file_path = download_file(r["url"])
           next unless file_path
@@ -404,7 +403,7 @@ module Bulkrax
       # TODO: add migration to Hyrax::UploadedFile so that it can accept filenames
       # ref: https://github.com/samvera/hyrax/blob/main/app/models/hyrax/uploaded_file.rb
       file = File.open(file_path)
-      uploaded_file = Hyrax::UploadedFile.create(file: file, user: @user)
+      uploaded_file = Hyrax::UploadedFile.create(file: file, user: @user, filename: file_name)
       file.close
       uploaded_file
     rescue => e

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -362,13 +362,54 @@ module Bulkrax
     def uploaded_s3_files(remote_files: {})
       return [] if remote_files.blank?
 
-      s3_bucket_name = ENV.fetch("STAGING_AREA_S3_BUCKET", "comet-staging-area-#{Rails.env}")
-      s3_bucket = Rails.application.config.staging_area_s3_connection
-                       .directories.get(s3_bucket_name)
+      # Check if the S3 bucket should be used
+      use_s3 = ENV.fetch("USE_S3", "false") == "true"
 
-      remote_files.map { |r| r["url"] }.map do |key|
-        s3_bucket.files.get(key)
-      end.compact
+      if use_s3
+        s3_bucket_name = ENV.fetch("STAGING_AREA_S3_BUCKET", "comet-staging-area-#{Rails.env}")
+        s3_bucket = Rails.application.config.staging_area_s3_connection
+                         .directories.get(s3_bucket_name)
+
+        remote_files.map { |r| r["url"] }.map do |key|
+          s3_bucket.files.get(key)
+        end.compact
+      else
+        # For local testing, create Hyrax::UploadedFile objects from URLs
+        remote_files.map do |r|
+          file_path = download_file(r["url"])
+          next unless file_path
+
+          create_uploaded_file(file_path, r["file_name"])
+        end.compact
+      end
+    end
+
+    def download_file(url)
+      require 'open-uri'
+      require 'tempfile'
+
+      begin
+        file = Tempfile.new
+        file.binmode
+        file.write(URI.open(url).read)
+        file.rewind
+        file.path
+      rescue => e
+        Rails.logger.debug "Failed to download file from #{url}: #{e.message}"
+        nil
+      end
+    end
+
+    def create_uploaded_file(file_path, file_name)
+      # TODO: add migration to Hyrax::UploadedFile so that it can accept filenames
+      # ref: https://github.com/samvera/hyrax/blob/main/app/models/hyrax/uploaded_file.rb
+      file = File.open(file_path)
+      uploaded_file = Hyrax::UploadedFile.create(file: file, user: @user)
+      file.close
+      uploaded_file
+    rescue => e
+      Rails.logger.debug "Failed to create Hyrax::UploadedFile for #{file_name}: #{e.message}"
+      nil
     end
 
     # @Override Destroy existing files with Hyrax::Transactions

--- a/db/migrate/20240806161142_add_file_name_to_uploaded_files.rb
+++ b/db/migrate/20240806161142_add_file_name_to_uploaded_files.rb
@@ -1,0 +1,5 @@
+class AddFileNameToUploadedFiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :uploaded_files, :filename, :string unless column_exists(:uploaded_files, :filename)
+  end
+end

--- a/db/migrate/20240806161142_add_file_name_to_uploaded_files.rb
+++ b/db/migrate/20240806161142_add_file_name_to_uploaded_files.rb
@@ -1,5 +1,5 @@
 class AddFileNameToUploadedFiles < ActiveRecord::Migration[6.1]
   def change
-    add_column :uploaded_files, :filename, :string unless column_exists(:uploaded_files, :filename)
+    add_column :uploaded_files, :filename, :string unless column_exists?(:uploaded_files, :filename)
   end
 end


### PR DESCRIPTION
Previously this code strictly downloaded from s3 buckets. This was limiting, and expands the ability to import remote files without s3, and override thumbnail urls if one is provided.

Issue: 
- https://github.com/scientist-softserv/adventist_knapsack/issues/708