### PR TITLE
Allow for only thumbnail url in csv

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -266,6 +266,7 @@ module Bulkrax
 
     def combined_files_with(remote_files:)
       thumbnail_url = self.attributes['thumbnail_url']
+      return [thumbnail_url] if remote_files.blank?
       @combined_files ||= (thumbnail_url.present? ? remote_files + [thumbnail_url] : remote_files)
     end
 


### PR DESCRIPTION
Handles situation where the csv has a thumbnail_url but no related_url to use as remote files.

Previously threw an error: `NoMethodError - undefined method + for nil:NilClass`

![Screenshot 2024-08-16 at 7 48 15 PM](https://github.com/user-attachments/assets/f16b0b26-bfd0-436d-b9e7-524af696054b)
