### PR TITLE
Prevent metadata duplication

### DIFF
--- a/app/models/concerns/bulkrax/has_matchers.rb
+++ b/app/models/concerns/bulkrax/has_matchers.rb
@@ -65,6 +65,7 @@ module Bulkrax
 
       parsed_metadata[name] ||= []
       parsed_metadata[name] += Array.wrap(value).flatten
+      parsed_metadata[name].uniq!
     end
 
     def set_parsed_object_data(object_multiple, object_name, name, index, value)


### PR DESCRIPTION
When the term Identifier is part of the metadata and used as source_identifier, it resulted in the value getting put into the metadata twice. Calling uniq! on the array removes any duplicate metadata, as there should never be a reason for the same metadata to be on a record twice.