### PR TITLE
🐛 Fix importers sorting for last run and next run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,11 @@ jobs:
         run: bundle exec rake spec
 
       - name: Upload coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: coverage-report-${{ matrix.ruby }}
-          path: coverage
+          path: coverage/**
+          include-hidden-files: true
 
   coverage:
     runs-on: ubuntu-latest
@@ -56,7 +57,7 @@ jobs:
 
     steps:
       - name: Download coverage report
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: coverage-report-2.7
           path: coverage

--- a/app/assets/javascripts/bulkrax/datatables.js
+++ b/app/assets/javascripts/bulkrax/datatables.js
@@ -67,7 +67,7 @@ Blacklight.onLoad(function() {
         { "data": "name" },
         { "data": "status_message" },
         { "data": "created_at" },
-        { "data": "download" },
+        { "data": "download", "orderable": false },
         { "data": "actions", "orderable": false }
       ],
       initComplete: function () {

--- a/app/models/bulkrax/importer_run.rb
+++ b/app/models/bulkrax/importer_run.rb
@@ -6,6 +6,9 @@ module Bulkrax
     has_many :statuses, as: :runnable, dependent: :destroy
     has_many :pending_relationships, dependent: :destroy
 
+    after_save :set_last_imported_at
+    after_save :set_next_import_at
+
     def parents
       pending_relationships.pluck(:parent_id).uniq
     end
@@ -14,6 +17,14 @@ module Bulkrax
       # An importer might not have a user, the CLI ingest need not assign a user.  As such, we
       # fallback to the configured user.
       importer.user || Bulkrax.fallback_user_for_importer_exporter_processing
+    end
+
+    def set_last_imported_at
+      importer.update(last_imported_at: importer.last_imported_at)
+    end
+
+    def set_next_import_at
+      importer.update(next_import_at: importer.next_import_at)
     end
   end
 end

--- a/db/migrate/20240916182737_add_last_imported_at_to_bulkrax_importers.rb
+++ b/db/migrate/20240916182737_add_last_imported_at_to_bulkrax_importers.rb
@@ -1,5 +1,5 @@
 class AddLastImportedAtToBulkraxImporters < ActiveRecord::Migration[5.1]
   def change
-    add_column :bulkrax_importers, :last_imported_at, :datetime
+    add_column :bulkrax_importers, :last_imported_at, :datetime unless column_exists?(:bulkrax_importers, :last_imported_at)
   end
 end

--- a/db/migrate/20240916182737_add_last_imported_at_to_bulkrax_importers.rb
+++ b/db/migrate/20240916182737_add_last_imported_at_to_bulkrax_importers.rb
@@ -1,0 +1,5 @@
+class AddLastImportedAtToBulkraxImporters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :bulkrax_importers, :last_imported_at, :datetime
+  end
+end

--- a/db/migrate/20240916182823_add_next_import_at_to_bulkrax_importers.rb
+++ b/db/migrate/20240916182823_add_next_import_at_to_bulkrax_importers.rb
@@ -1,0 +1,5 @@
+class AddNextImportAtToBulkraxImporters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :bulkrax_importers, :next_import_at, :datetime
+  end
+end

--- a/db/migrate/20240916182823_add_next_import_at_to_bulkrax_importers.rb
+++ b/db/migrate/20240916182823_add_next_import_at_to_bulkrax_importers.rb
@@ -1,5 +1,5 @@
 class AddNextImportAtToBulkraxImporters < ActiveRecord::Migration[5.1]
   def change
-    add_column :bulkrax_importers, :next_import_at, :datetime
+    add_column :bulkrax_importers, :next_import_at, :datetime unless column_exists?(:bulkrax_importers, :next_import_at)
   end
 end

--- a/lib/tasks/bulkrax_tasks.rake
+++ b/lib/tasks/bulkrax_tasks.rake
@@ -141,4 +141,25 @@ namespace :bulkrax do
   rescue => e
     puts "(#{e.message})"
   end
+
+  desc "Resave importers"
+  task resave_importers: :environment do
+    if defined?(::Hyku)
+      Account.find_each do |account|
+        next if account.name == "search"
+        switch!(account)
+        puts "=============== updating #{account.name} ============"
+
+        resave_importers
+
+        puts "=============== finished updating #{account.name} ============"
+      end
+    else
+      resave_importers
+    end
+  end
+
+  def resave_importers
+    Bulkrax::Importer.find_each(&:save!)
+  end
 end


### PR DESCRIPTION
# Summary
## 🐛 Fix importers sorting for last run and next run

7d985dda63bb027fb9f1cb7416709a54a420968a

This commit will fix the sorting error that happens when the user is on
the importers index and attempts to sort by the last run or next run. We
add some migrations to add fields that the datatables can use so it can
sort properly. Previously, this was not working because the
last_imported_at and next_import_at fields were actually methods on the
importer_run object and not the importer object.  We are adding a few
callbacks to the importer and importer_run models to ensure that the
fields are properly set when they are called from either the web or the
worker.

Ref:
- https://github.com/samvera/bulkrax/issues/956

https://github.com/user-attachments/assets/65c5b70e-5c9a-40ac-897d-c417fe24b636

## 🤖 Update upload-artifact and download-artifact

aca33e568c06236c5652a0e500da33c5d46cba10

CI was getting errors because the versions we were previously using were
deprecated.  This commit updates the actions to the latest versions.

## 🐛 Remove Downloadable Files sorting

d4d4749b543ca0f6631edfc61287491012b36098

The downloadable files sorting was broken plus, it's not clear now a
downloadable file should be sorted.

## ⚙️ Add guard for new migrations

7011d726bd9f2f37dc19a5f8bddb4089c09c3827

This commit will add a guard to the new migrations to ensure that they
do not run if the columns already exist in the database.

# Note

To get the changes all the Importers need to be updated, something like:
```rb
Importers.all.each(&:save)
```