### PR TITLE
🤖 Update upload-artifact and download-artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,11 @@ jobs:
         run: bundle exec rake spec
 
       - name: Upload coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: coverage-report-${{ matrix.ruby }}
-          path: coverage
+          path: coverage/**
+          include-hidden-files: true
 
   coverage:
     runs-on: ubuntu-latest
@@ -56,7 +57,7 @@ jobs:
 
     steps:
       - name: Download coverage report
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: coverage-report-2.7
           path: coverage


### PR DESCRIPTION
CI was getting errors because the versions we were previously using were
deprecated.  This commit updates the actions to the latest versions.