### PR TITLE
Add import_url to file set attributes

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -271,7 +271,7 @@ module Bulkrax
       thumbnail_url = HashWithIndifferentAccess.new(self.attributes)['thumbnail_url']
       all_remote_files = merge_thumbnails(remote_files: attrs["remote_files"], thumbnail_url: thumbnail_url)
       # combine local & remote files [Array < Hash &/or String]
-      all_local_files = self.attributes['file']
+      all_local_files = self.attributes['file'] || []
       all_files = all_local_files + all_remote_files
 
       # collect all uploaded files [Array < Hyrax::UploadedFile]
@@ -307,7 +307,9 @@ module Bulkrax
         when String
           {}
         else
-          f.reject { |key, _| key.to_s == 'url' || key.to_s == 'file_name' }
+          temp = f.reject { |key, _| key.to_s == 'url' || key.to_s == 'file_name' }
+          temp['import_url'] = f['url']
+          temp
         end
       end
 


### PR DESCRIPTION
This adds import_url to the attributes for creating a Valkyrized file set.

To actually save the import_url on a file set, the application needs to:
- add import_url to the file_set metadata attributes in your app
- decorate Hyrax::WorkUploadsHandler to add import_url to the file_set_args method

Additionally it defaults local_files to an empty array in case there are no local files.