### PR TITLE
Avoid false positive from `.try(:internal_resource)`

### DIFF
--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -98,7 +98,22 @@ module Bulkrax
     attr_writer :collection_model_class
 
     def collection_model_internal_resource
-      collection_model_class.try(:internal_resource) || collection_model_class.to_s
+      # WARN: Using #try on :internal_resource can yield unexpected results.
+      # If the method is undefined, it can return a truthy value instead of
+      # the typical nil.
+      #
+      # E.g.
+      # ```ruby
+      # Hyrax::FileSet.try(:internal_resource) || 'hi'
+      # => #<Dry::Types::Result::Failure input=:internal_resource error=...
+      # ```
+      ir = begin
+             collection_model_class.internal_resource
+           rescue NoMethodError
+             nil
+           end
+
+      ir.presence || collection_model_class.to_s
     end
 
     def file_model_class
@@ -108,7 +123,22 @@ module Bulkrax
     attr_writer :file_model_class
 
     def file_model_internal_resource
-      file_model_class.try(:internal_resource) || file_model_class.to_s
+      # WARN: Using #try on :internal_resource can yield unexpected results.
+      # If the method is undefined, it can return a truthy value instead of
+      # the typical nil.
+      #
+      # E.g.
+      # ```ruby
+      # Hyrax::FileSet.try(:internal_resource) || 'hi'
+      # => #<Dry::Types::Result::Failure input=:internal_resource error=...
+      # ```
+      ir = begin
+             file_model_class.internal_resource
+           rescue NoMethodError
+             nil
+           end
+
+      ir.presence || file_model_class.to_s
     end
 
     def curation_concerns
@@ -118,7 +148,24 @@ module Bulkrax
     attr_writer :curation_concerns
 
     def curation_concern_internal_resources
-      curation_concerns.map { |cc| cc.try(:internal_resource) || cc.to_s }.uniq
+      curation_concerns.map do |cc|
+        # WARN: Using #try on :internal_resource can yield unexpected results.
+        # If the method is undefined, it can return a truthy value instead of
+        # the typical nil.
+        #
+        # E.g.
+        # ```ruby
+        # Hyrax::FileSet.try(:internal_resource) || 'hi'
+        # => #<Dry::Types::Result::Failure input=:internal_resource error=...
+        # ```
+        ir = begin
+               cc.internal_resource
+             rescue NoMethodError
+               nil
+             end
+
+        ir.presence || cc.to_s
+      end.uniq
     end
 
     attr_writer :ingest_queue_name

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -107,13 +107,11 @@ module Bulkrax
       # Hyrax::FileSet.try(:internal_resource) || 'hi'
       # => #<Dry::Types::Result::Failure input=:internal_resource error=...
       # ```
-      ir = begin
-             collection_model_class.internal_resource
-           rescue NoMethodError
-             nil
-           end
-
-      ir.presence || collection_model_class.to_s
+      if collection_model_class.respond_to?(:internal_resource)
+        collection_model_class.internal_resource
+      else
+        collection_model_class.to_s
+      end
     end
 
     def file_model_class
@@ -132,13 +130,11 @@ module Bulkrax
       # Hyrax::FileSet.try(:internal_resource) || 'hi'
       # => #<Dry::Types::Result::Failure input=:internal_resource error=...
       # ```
-      ir = begin
-             file_model_class.internal_resource
-           rescue NoMethodError
-             nil
-           end
-
-      ir.presence || file_model_class.to_s
+      if file_model_class.respond_to?(:internal_resource)
+        file_model_class.internal_resource
+      else
+        file_model_class.to_s
+      end
     end
 
     def curation_concerns
@@ -158,13 +154,7 @@ module Bulkrax
         # Hyrax::FileSet.try(:internal_resource) || 'hi'
         # => #<Dry::Types::Result::Failure input=:internal_resource error=...
         # ```
-        ir = begin
-               cc.internal_resource
-             rescue NoMethodError
-               nil
-             end
-
-        ir.presence || cc.to_s
+        cc.respond_to?(:internal_resource) ? cc.internal_resource : cc.to_s
       end.uniq
     end
 


### PR DESCRIPTION
Using `#try` on `:internal_resource` can yield unexpected results. If the method is undefined, it can return a truthy value instead of the typical `nil`.

E.g.

```ruby
Hyrax::FileSet.try(:internal_resource) || 'hi'
=> #<Dry::Types::Result::Failure input=:internal_resource error=#<Dry::Struct::Error: [Hyrax::FileSet.new] can't convert Symbol into Hash>>
```

E.g. 

```ruby
Bulkrax.collection_model_internal_resource
=> #<Dry::Types::Result::Failure input=:internal_resource error=#<Dry::Struct::Error: [CollectionResource.new] can't convert Symbol into Hash>>
```

This was discovered while trying to export Valkyrie Resources from HykuUP (see screenshot) 

<details><summary>Screenshot</summary>

![image](https://github.com/user-attachments/assets/25c7f59c-b44a-446e-aae8-4b4ff34b611e)

</details>