### PR TITLE
Access the default split pattern from the parser instead of the config

### DIFF
--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -33,7 +33,7 @@ module Bulkrax
 
     def process_split
       if self.split.is_a?(TrueClass)
-        @result = @result.split(Bulkrax.multi_value_element_split_on)
+        @result = @result.split(ApplicationParser.multi_value_element_split_on)
       elsif self.split
         @result = @result.split(Regexp.new(self.split))
         @result = @result.map(&:strip).select(&:present?)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -129,7 +129,7 @@ module Bulkrax
     def add_file
       self.parsed_metadata['file'] ||= []
       if record['file']&.is_a?(String)
-        self.parsed_metadata['file'] = record['file'].split(Bulkrax.multi_value_element_split_on)
+        self.parsed_metadata['file'] = record['file'].split(parser.multi_value_element_split_on)
       elsif record['file'].is_a?(Array)
         self.parsed_metadata['file'] = record['file']
       end
@@ -350,7 +350,7 @@ module Bulkrax
       return [] unless parent_field_mapping.present? && record[parent_field_mapping].present?
 
       identifiers = []
-      split_references = record[parent_field_mapping].split(Bulkrax.multi_value_element_split_on)
+      split_references = record[parent_field_mapping].split(parser.multi_value_element_split_on)
       split_references.each do |c_reference|
         matching_collection_entries = importerexporter.entries.select do |e|
           (e.raw_metadata&.[](source_identifier) == c_reference) &&

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -34,6 +34,10 @@ module Bulkrax
       true
     end
 
+    def self.multi_value_element_split_on
+      Bulkrax.multi_value_element_split_on
+    end
+
     def initialize(importerexporter)
       @importerexporter = importerexporter
       @headers = []

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -338,7 +338,7 @@ module Bulkrax
         file_mapping = Bulkrax.field_mappings.dig(self.class.to_s, 'file', :from)&.first&.to_sym || :file
         next if r[file_mapping].blank?
 
-        r[file_mapping].split(Bulkrax.multi_value_element_split_on).map do |f|
+        r[file_mapping].split(multi_value_element_split_on).map do |f|
           file = File.join(path_to_files, f.tr(' ', '_'))
           if File.exist?(file) # rubocop:disable Style/GuardClause
             file
@@ -366,7 +366,7 @@ module Bulkrax
       entry_uid ||= if Bulkrax.fill_in_blank_source_identifiers.present?
                       Bulkrax.fill_in_blank_source_identifiers.call(self, records.find_index(collection_hash))
                     else
-                      collection_hash[:title].split(Bulkrax.multi_value_element_split_on).first
+                      collection_hash[:title].split(multi_value_element_split_on).first
                     end
 
       entry_uid


### PR DESCRIPTION
Transfer responsibility of accessing the split pattern from the config to the `ApplicationParser`. This enables the default split pattern to be overwritten

Hyku will soon get an `Account` setting that allows for per-tenant overrides for the default split pattern. This change enables that feature

The default value is still set in the config. Existing installations should see no difference in behavior; this change is backwards-compatible