### PR TITLE
speed up entries display by no longer looking at all the status objects

### DIFF
--- a/app/controllers/concerns/bulkrax/datatables_behavior.rb
+++ b/app/controllers/concerns/bulkrax/datatables_behavior.rb
@@ -132,7 +132,7 @@ module Bulkrax
           status_message: status_message_for(e),
           type: e.type,
           updated_at: e.updated_at,
-          errors: e.latest_status&.error_class&.present? ? view_context.link_to(e.latest_status.error_class, view_context.item_entry_path(item, e), title: e.latest_status.error_message) : "",
+          errors: e.status_message == 'Failed' ? view_context.link_to(e.error_class, view_context.item_entry_path(item, e)) : "",
           actions: entry_util_links(e, item)
         }
       end

--- a/app/models/bulkrax/status.rb
+++ b/app/models/bulkrax/status.rb
@@ -2,7 +2,7 @@
 
 module Bulkrax
   class Status < ApplicationRecord
-    belongs_to :statusable, polymorphic: true, denormalize: { fields: %i[status_message], if: :latest? }
+    belongs_to :statusable, polymorphic: true, denormalize: { fields: %i[status_message error_class], if: :latest? }
     belongs_to :runnable, polymorphic: true
     serialize :error_backtrace, Array
 

--- a/db/migrate/20241203010707_entry_error_denormalization.rb
+++ b/db/migrate/20241203010707_entry_error_denormalization.rb
@@ -1,4 +1,4 @@
-class EntryErrorDenormalization < ActiveRecord::Migration[6.1]
+class EntryErrorDenormalization < ActiveRecord::Migration[5.1]
   def change
     add_column :bulkrax_entries, :error_class, :string unless column_exists?(:bulkrax_entries, :error_class)
     add_column :bulkrax_importers, :error_class, :string unless column_exists?(:bulkrax_importers, :error_class)

--- a/db/migrate/20241203010707_entry_error_denormalization.rb
+++ b/db/migrate/20241203010707_entry_error_denormalization.rb
@@ -1,7 +1,7 @@
 class EntryErrorDenormalization < ActiveRecord::Migration[6.1]
   def change
     add_column :bulkrax_entries, :error_class, :string unless column_exists?(:bulkrax_entries, :error_class)
-    add_column :bulkrax_importers, :error_class, :string unless column_exists?(:bulkrax_entries, :error_class)
-    add_column :bulkrax_exporters, :error_class, :string unless column_exists?(:bulkrax_entries, :error_class)
+    add_column :bulkrax_importers, :error_class, :string unless column_exists?(:bulkrax_importers, :error_class)
+    add_column :bulkrax_exporters, :error_class, :string unless column_exists?(:bulkrax_exporters, :error_class)
   end
 end

--- a/db/migrate/20241203010707_entry_error_denormalization.rb
+++ b/db/migrate/20241203010707_entry_error_denormalization.rb
@@ -1,5 +1,7 @@
 class EntryErrorDenormalization < ActiveRecord::Migration[6.1]
   def change
     add_column :bulkrax_entries, :error_class, :string unless column_exists?(:bulkrax_entries, :error_class)
+    add_column :bulkrax_importers, :error_class, :string unless column_exists?(:bulkrax_entries, :error_class)
+    add_column :bulkrax_exporters, :error_class, :string unless column_exists?(:bulkrax_entries, :error_class)
   end
 end

--- a/db/migrate/20241203010707_entry_error_denormalization.rb
+++ b/db/migrate/20241203010707_entry_error_denormalization.rb
@@ -1,0 +1,5 @@
+class EntryErrorDenormalization < ActiveRecord::Migration[6.1]
+  def change
+    add_column :bulkrax_entries, :error_class, :string unless column_exists?(:bulkrax_entries, :error_class)
+  end
+end

--- a/db/migrate/20241205212513_faster_first_entry.rb
+++ b/db/migrate/20241205212513_faster_first_entry.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class FasterFirstEntry < ActiveRecord::Migration[5.2]
+  def change
+    add_index :bulkrax_entries, [:importerexporter_id, :importerexporter_type, :id], name: 'index_bulkrax_entries_on_importerexporter_id_type_and_id' unless index_exists?(:bulkrax_entries, [:importerexporter_id, :importerexporter_type, :id],
+      name: 'index_bulkrax_entries_on_importerexporter_id_type_and_id')
+  end
+end

--- a/lib/tasks/bulkrax_tasks.rake
+++ b/lib/tasks/bulkrax_tasks.rake
@@ -9,7 +9,7 @@ namespace :bulkrax do
                                    progress_mark: ' ',
                                    remainder_mark: "\u{FF65}")
     Bulkrax::Status.latest_by_statusable.includes(:statusable).find_each do |status|
-      status.statusable.update(status_message: status.status_message)
+      status.statusable.update(status_message: status.status_message, error_class: status.error_class)
       @progress.increment
     end
   end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2024_12_03_010707) do
     t.boolean "include_thumbnails", default: false
     t.boolean "generated_metadata", default: false
     t.string "status_message", default: "Pending"
+    t.string "error_class"
     t.index ["user_id"], name: "index_bulkrax_exporters_on_user_id"
   end
 
@@ -102,6 +103,8 @@ ActiveRecord::Schema.define(version: 2024_12_03_010707) do
     t.integer "total_file_set_entries", default: 0
     t.integer "processed_works", default: 0
     t.integer "failed_works", default: 0
+    t.integer "processed_children", default: 0
+    t.integer "failed_children", default: 0
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 
@@ -122,6 +125,7 @@ ActiveRecord::Schema.define(version: 2024_12_03_010707) do
     t.string "status_message", default: "Pending"
     t.datetime "last_imported_at"
     t.datetime "next_import_at"
+    t.string "error_class"
     t.index ["user_id"], name: "index_bulkrax_importers_on_user_id"
   end
 

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_16_182823) do
+ActiveRecord::Schema.define(version: 2024_12_03_010707) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "name"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 2024_09_16_182823) do
     t.string "importerexporter_type", default: "Bulkrax::Importer"
     t.integer "import_attempts", default: 0
     t.string "status_message", default: "Pending"
+    t.string "error_class"
     t.index ["identifier", "importerexporter_id", "importerexporter_type"], name: "bulkrax_identifier_idx"
     t.index ["importerexporter_id", "importerexporter_type"], name: "bulkrax_entries_importerexporter_idx"
     t.index ["type"], name: "index_bulkrax_entries_on_type"

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_03_010707) do
+ActiveRecord::Schema.define(version: 2024_12_05_212513) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "name"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2024_12_03_010707) do
     t.string "status_message", default: "Pending"
     t.string "error_class"
     t.index ["identifier", "importerexporter_id", "importerexporter_type"], name: "bulkrax_identifier_idx"
+    t.index ["importerexporter_id", "importerexporter_type", "id"], name: "index_bulkrax_entries_on_importerexporter_id_type_and_id"
     t.index ["importerexporter_id", "importerexporter_type"], name: "bulkrax_entries_importerexporter_idx"
     t.index ["type"], name: "index_bulkrax_entries_on_type"
   end
@@ -103,8 +104,6 @@ ActiveRecord::Schema.define(version: 2024_12_03_010707) do
     t.integer "total_file_set_entries", default: 0
     t.integer "processed_works", default: 0
     t.integer "failed_works", default: 0
-    t.integer "processed_children", default: 0
-    t.integer "failed_children", default: 0
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 


### PR DESCRIPTION
we lose the error message in the title, you have to click through to see it but page speeds go up 100x.

Release note:
Requires running `rails bulkrax:update_status_messages` for error messages to display.