### PR TITLE
Fixes issues with filesets exporting in Valkyrie

### DIFF
--- a/app/models/concerns/bulkrax/export_behavior.rb
+++ b/app/models/concerns/bulkrax/export_behavior.rb
@@ -29,7 +29,7 @@ module Bulkrax
       return if file_set.original_file.blank?
       if file_set.original_file.respond_to?(:original_filename) # valkyrie
         fn = file_set.original_file.original_filename
-        mime =::Marcel::MimeType.for(file_set.original_file.file.io)
+        mime = ::Marcel::MimeType.for(file_set.original_file.file.io)
       else # original non valkyrie version
         fn = file_set.original_file.file_name.first
         mime = ::Marcel::MimeType.for(file_set.original_file.mime_type)

--- a/app/models/concerns/bulkrax/export_behavior.rb
+++ b/app/models/concerns/bulkrax/export_behavior.rb
@@ -26,11 +26,15 @@ module Bulkrax
 
     # Prepend the file_set id to ensure a unique filename and also one that is not longer than 255 characters
     def filename(file_set)
-      # NOTE: Will this work with Valkyrie?
       return if file_set.original_file.blank?
-      fn = file_set.original_file.file_name.first
-      mime = ::Marcel::MimeType.for(file_set.original_file.mime_type)
-      ext_mime = ::Marcel::MimeType.for(file_set.original_file.file_name)
+      if file_set.original_file.respond_to?(:original_filename) # valkyrie
+        fn = file_set.original_file.original_filename
+        mime =::Marcel::MimeType.for(file_set.original_file.file.io)
+      else # original non valkyrie version
+        fn = file_set.original_file.file_name.first
+        mime = ::Marcel::MimeType.for(file_set.original_file.mime_type)
+      end
+      ext_mime = ::Marcel::MimeType.for(name: fn)
       if fn.include?(file_set.id) || importerexporter.metadata_only?
         filename = "#{fn}.#{mime.to_sym}"
         filename = fn if mime.to_s == ext_mime.to_s

--- a/app/models/concerns/bulkrax/export_behavior.rb
+++ b/app/models/concerns/bulkrax/export_behavior.rb
@@ -32,7 +32,7 @@ module Bulkrax
         mime = ::Marcel::MimeType.for(file_set.original_file.file.io)
       else # original non valkyrie version
         fn = file_set.original_file.file_name.first
-        mime = ::Marcel::MimeType.for(file_set.original_file.mime_type)
+        mime = ::Marcel::MimeType.for(declared_type: file_set.original_file.mime_type)
       end
       ext_mime = ::Marcel::MimeType.for(name: fn)
       if fn.include?(file_set.id) || importerexporter.metadata_only?

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -244,15 +244,19 @@ module Bulkrax
       record = Bulkrax.object_factory.find(identifier)
       return unless record
 
-      file_sets = record.file_set? ? Array.wrap(record) : record.file_sets
+      if record.file_set?
+        file_sets = Array.wrap(record)
+      else # for valkyrie
+        file_sets = record.respond_to?(:file_sets) ? record.file_sets : record.members&.select{|m| m.file_set?}
+      end
       file_sets << record.thumbnail if exporter.include_thumbnails && record.thumbnail.present? && record.work?
       file_sets.each do |fs|
         path = File.join(exporter_export_path, folder_count, 'files')
         FileUtils.mkdir_p(path) unless File.exist? path
         file = filename(fs)
         next if file.blank? || fs.original_file.blank?
-
-        io = open(fs.original_file.uri)
+        byebug
+        io = fs.original_file.respond_to?(:uri) ? (fs.original_file.uri) : fs.original_file.file.io
         File.open(File.join(path, file), 'wb') do |f|
           f.write(io.read)
           f.close

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -247,7 +247,7 @@ module Bulkrax
       if record.file_set?
         file_sets = Array.wrap(record)
       else # for valkyrie
-        file_sets = record.respond_to?(:file_sets) ? record.file_sets : record.members&.select{|m| m.file_set?}
+        file_sets = record.respond_to?(:file_sets) ? record.file_sets : record.members&.select(&:file_set?)
       end
       file_sets << record.thumbnail if exporter.include_thumbnails && record.thumbnail.present? && record.work?
       file_sets.each do |fs|
@@ -255,8 +255,8 @@ module Bulkrax
         FileUtils.mkdir_p(path) unless File.exist? path
         file = filename(fs)
         next if file.blank? || fs.original_file.blank?
-        byebug
-        io = fs.original_file.respond_to?(:uri) ? (fs.original_file.uri) : fs.original_file.file.io
+
+        io = fs.original_file.respond_to?(:uri) ? fs.original_file.uri : fs.original_file.file.io
         File.open(File.join(path, file), 'wb') do |f|
           f.write(io.read)
           f.close

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -255,7 +255,7 @@ module Bulkrax
         file = filename(fs)
         next if file.blank? || fs.original_file.blank?
 
-        io = fs.original_file.respond_to?(:uri) ? fs.original_file.uri : fs.original_file.file.io
+        io = fs.original_file.respond_to?(:uri) ? open(fs.original_file.uri) : fs.original_file.file.io
         File.open(File.join(path, file), 'wb') do |f|
           f.write(io.read)
           f.close

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -244,9 +244,8 @@ module Bulkrax
       record = Bulkrax.object_factory.find(identifier)
       return unless record
 
-      if record.file_set?
-        file_sets = Array.wrap(record)
-      else # for valkyrie
+      file_sets = Array.wrap(record) if record.file_set?
+      if file_sets.nil? # for valkyrie
         file_sets = record.respond_to?(:file_sets) ? record.file_sets : record.members&.select(&:file_set?)
       end
       file_sets << record.thumbnail if exporter.include_thumbnails && record.thumbnail.present? && record.work?

--- a/app/parsers/bulkrax/parser_export_record_set.rb
+++ b/app/parsers/bulkrax/parser_export_record_set.rb
@@ -173,7 +173,7 @@ module Bulkrax
       # @see https://github.com/samvera/hyrax/blob/64c0bbf0dc0d3e1b49f040b50ea70d177cc9d8f6/app/indexers/hyrax/work_indexer.rb#L15-L18
       def file_sets
         @file_sets ||= ParserExportRecordSet.in_batches(candidate_file_set_ids) do |batch_of_ids|
-          fsq = "has_model_ssim:#{Bulkrax.file_model_internal_resource} AND id:(\"" + batch_of_ids.join('" OR "') + "\")"
+          fsq = "has_model_ssim:\"#{Bulkrax.file_model_internal_resource.demodulize}\" AND id:(\"" + batch_of_ids.join('" OR "') + "\")"
           fsq += extra_filters if extra_filters.present?
           Bulkrax.object_factory.query(
             fsq,


### PR DESCRIPTION
Fixes issues with FileSets exporting in Valkyrie versions of Hyrax/Hyku

refs #990 

- demodulized the solr fileset call and wrapped it in quotes so that it doesn't throw solr errors.
- added fileset name call for valkyrie. verifies mime type like in the original non-valkyrie version. (this was previously noted as possibly not working with valkyrie. the errors didn't show because the initial solr error prevented filesets from being found in solr in the first place)