### PR TITLE
⬆️ Up Bagit dependency to 0.6.0

### DIFF
--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency 'rails', '>= 5.1.6'
-  s.add_dependency 'bagit', '~> 0.4.6'
+  s.add_dependency 'bagit', '~> 0.6.0'
   s.add_dependency 'coderay'
   s.add_dependency 'denormalize_fields'
   s.add_dependency 'marcel'


### PR DESCRIPTION
This commit will bump the Bagit dependency to 0.6.0 which allows for Ruby 3.3 support.

https://github.com/tipr/bagit/releases

Nothing in the release indicate a breaking change.