### PR TITLE
Add guard to uploaded_files migration

### DIFF
--- a/db/migrate/20240806161142_add_file_name_to_uploaded_files.rb
+++ b/db/migrate/20240806161142_add_file_name_to_uploaded_files.rb
@@ -1,7 +1,5 @@
 class AddFileNameToUploadedFiles < ActiveRecord::Migration[5.2]
   def change
-    if table_exists?(:uploaded_files)
-      add_column :uploaded_files, :filename, :string unless column_exists?(:uploaded_files, :filename)
-    end
+    add_column :uploaded_files, :filename, :string if table_exists?(:uploaded_files) && !column_exists?(:uploaded_files, :filename)
   end
 end

--- a/db/migrate/20240806161142_add_file_name_to_uploaded_files.rb
+++ b/db/migrate/20240806161142_add_file_name_to_uploaded_files.rb
@@ -1,5 +1,7 @@
 class AddFileNameToUploadedFiles < ActiveRecord::Migration[5.2]
   def change
-    add_column :uploaded_files, :filename, :string unless column_exists?(:uploaded_files, :filename)
+    if table_exists?(:uploaded_files)
+      add_column :uploaded_files, :filename, :string unless column_exists?(:uploaded_files, :filename)
+    end
   end
 end


### PR DESCRIPTION
This commit will check if uploaded_files is a table before adding the file_name column to it.  In a Hydra application, it is not so this was crashing.