### PR TITLE
🧹 Add guard for collection_model_class

### DIFF
--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -92,7 +92,7 @@ module Bulkrax
     end
 
     def collection_model_class
-      @collection_model_class ||= Collection
+      @collection_model_class ||= Collection if defined?(::Hyrax)
     end
 
     attr_writer :collection_model_class


### PR DESCRIPTION
The Collection constant is primarily a Hyrax concept so we will guard it to allow Hydra applications to use Bulkrax.