### PR TITLE
fix race condition for statuses on export

### DIFF
--- a/app/jobs/bulkrax/export_work_job.rb
+++ b/app/jobs/bulkrax/export_work_job.rb
@@ -26,7 +26,7 @@ module Bulkrax
         end
         # rubocop:enable Rails/SkipsModelValidations
       end
-      return entry if exporter_run.enqueued_records.positive?
+      return entry if exporter_run.reload.enqueued_records.positive?
 
       if exporter_run.failed_records.positive?
         exporter_run.exporter.set_status_info('Complete (with failures)')


### PR DESCRIPTION
There are times when the last entries of an export have an old version of an ExporterRun and they think there are still are enqueued record when other threads have already processed them. This causes the ExporterRun to potentially never update the status and it appears to never complete (stuck in pending state, despite the export being finished). This PR reloads the ExporterRun before checking to make sure it is up to date and the status update runs.