### PR TITLE
Revert ObjectFactory#find method returning false instead of nil on missing object

### DIFF
--- a/app/factories/bulkrax/object_factory_interface.rb
+++ b/app/factories/bulkrax/object_factory_interface.rb
@@ -319,9 +319,9 @@ module Bulkrax
     #
     # @return [Object] when we've found the object by the entry's :id or by it's
     #         source_identifier
-    # @return [FalseClass] when we cannot find the object.
+    # @return [NilClass] when we cannot find the object.
     def find
-      find_by_id || search_by_identifier || false
+      find_by_id || search_by_identifier || nil
     end
 
     ##


### PR DESCRIPTION
Changed in Hyrax 4 valkyrie support (#872). several bugs around this change have been guarded against, but a full audit was done and there is nothing that requires this method to continue to return false and several places that still expect it to be nil. So we are reverting to nil when an object isnt found in the factory