### PR TITLE
update the bulkrax factory to support flexible metadata while maintaining non-flexi support

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -81,7 +81,8 @@ module Bulkrax
       return false unless field_supported?(field: field, model: model)
 
       if model.respond_to?(:schema)
-        dry_type = model.new.singleton_class.schema.key(field.to_sym)
+        schema = model.new.singleton_class.schema || model.schema
+        dry_type = schema.key(field.to_sym)
         return true if dry_type.respond_to?(:primitive) && dry_type.primitive == Array
 
         false
@@ -193,7 +194,8 @@ module Bulkrax
       @schema_properties_map ||= {}
 
       klass_key = klass.name
-      @schema_properties_map[klass_key] = klass.new.singleton_class.schema.map { |k| k.name.to_s } unless @schema_properties_map.key?(klass_key)
+      schema = klass.new.singleton_class.schema || klass.schema
+      @schema_properties_map[klass_key] = schema.map { |k| k.name.to_s } unless @schema_properties_map.key?(klass_key)
 
       @schema_properties_map[klass_key]
     end

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -81,7 +81,7 @@ module Bulkrax
       return false unless field_supported?(field: field, model: model)
 
       if model.respond_to?(:schema)
-        dry_type = model.schema.key(field.to_sym)
+        dry_type = model.new.singleton_class.schema.key(field.to_sym)
         return true if dry_type.respond_to?(:primitive) && dry_type.primitive == Array
 
         false
@@ -193,7 +193,7 @@ module Bulkrax
       @schema_properties_map ||= {}
 
       klass_key = klass.name
-      @schema_properties_map[klass_key] = klass.schema.map { |k| k.name.to_s } unless @schema_properties_map.key?(klass_key)
+      @schema_properties_map[klass_key] = klass.new.singleton_class.schema.map { |k| k.name.to_s } unless @schema_properties_map.key?(klass_key)
 
       @schema_properties_map[klass_key]
     end


### PR DESCRIPTION
This method is 100% compatible with non-flexible metadata Valkyrie objects so does not require guards or flags.