### PR TITLE
:bug: Fix parser field visibility on importer edit form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gemspec
 gem 'blacklight'
 gem 'bootstrap-sass', '~> 3.4.1'
 gem 'coderay'
+gem 'concurrent-ruby', '1.3.4'
 gem 'factory_bot_rails'
 
 # Conditional logic based on Ruby version

--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -2,7 +2,7 @@
 // All this logic will automatically be available in application.js.
 
 function prepBulkrax(event) {
-  if($('form#new_importer').length < 1) {
+  if($('form#new_importer, form.edit_importer').length < 1) {
     return true;
   }
 


### PR DESCRIPTION


## BEFORE

previously the edit form would display all parser fields regardless if which parser was selected. This also was preventing a user form attaching a file.

![image](https://github.com/user-attachments/assets/9599bf34-10c9-4877-9d6a-f2b878ffd429)

## AFTER

![Zight Recording 2025-01-17 at 12 41 52 PM](https://github.com/user-attachments/assets/167e16fe-0d08-489d-b73c-971818624e27)

# Notes

## :bug: Fix parser field visibility on importer edit form

2356df259189c0b5c7e0339af8379dc1ca4ae956

The form initialization check was previously only looking for new forms
(#new_importer), causing the JavaScript field visibility logic to be
skipped entirely on edit pages. This meant parser-specific fields weren't
being properly hidden/shown when editing existing importers.

Added .edit_importer to the form check to ensure the field visibility
logic runs on both new and edit forms.

## Pin concurrent-ruby to v1.3.4 to maintain logger dependency

93ddfaed76876d2be956955eee27af60ede483ac

- Addresses logger dependency removal in concurrent-ruby v1.3.5
- Ensures compatibility with Rails versions before 7.1
