### PR TITLE
🐛 Fix importing CSV as attachment

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -379,9 +379,15 @@ module Bulkrax
     # We expect a single CSV at the top level of the zip in the CSVParser
     # but we are willing to go look for it if need be
     def real_import_file_path
-      return Dir["#{importer_unzip_path}/**/*.csv"].first if file? && zip?
+      return Dir["#{importer_unzip_path}/**/*.csv"].reject { |path| in_files_dir?(path) }.first if file? && zip?
 
       parser_fields['import_file_path']
+    end
+
+    # If there are CSVs that are meant to be attachments in the files directory,
+    # we don't want to consider them as the import CSV
+    def in_files_dir?(path)
+      File.dirname(path).ends_with?('files')
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, if an importer has a CSV file as an attachment, the importer would fail because it would try to parse the attached CSV as the importer CSV.  This commit will add a condition to only look for a CSV file that is NOT in the `/files` directory.

Ref:
- https://github.com/samvera/bulkrax/issues/989