### PR TITLE
🐛 Cleaning up UI on importers show

### DIFF
--- a/app/assets/javascripts/bulkrax/datatables.js
+++ b/app/assets/javascripts/bulkrax/datatables.js
@@ -3,6 +3,10 @@ Blacklight.onLoad(function() {
     $('#importer-show-table').DataTable( {
       'processing': true,
       'serverSide': true,
+      'width': '100%',
+      'autoWidth': false,
+      'scrollX': true,
+      'scrollCollapse': true,
       "ajax": window.location.href.replace(/(\/(importers|exporters)\/\d+)/, "$1/entry_table.json"),
       "pageLength": 30,
       "lengthMenu": [[30, 100, 200], [30, 100, 200]],
@@ -15,6 +19,14 @@ Blacklight.onLoad(function() {
         { "data": "errors", "orderable": false },
         { "data": "actions", "orderable": false }
       ],
+      drawCallback: function() {
+        // Remove the inline styles that DataTables adds to the scrollHeadInner and table elements
+        // it's not perfect but better than the style being applied
+        setTimeout(function() {
+          $('.dataTables_scrollHeadInner').removeAttr('style');
+          $('.table.table-striped.dataTable.no-footer').removeAttr('style');
+        }, 100);
+      },
       initComplete: function () {
         // Add entry class filter
         entrySelect.bind(this)()

--- a/app/views/bulkrax/importers/show.html.erb
+++ b/app/views/bulkrax/importers/show.html.erb
@@ -1,10 +1,10 @@
-<div class="col-xs-12 main-header">
+<div class="col-xs-12 main-header d-flex justify-content-between align-items-center">
   <h1><span class="fa fa-cloud-upload" aria-hidden="true"></span> Importer: <%= @importer.name %></h1>
   <div class="pull-right">
-    <%= link_to 'Download Original File', importer_original_file_path(@importer.id), class: 'btn btn-primary', data: { turbolinks: false } if @importer.original_file %>
+    <%= link_to 'Download Original File', importer_original_file_path(@importer.id), class: 'btn btn-primary text-nowrap', data: { turbolinks: false } if @importer.original_file %>
     <% if @importer.failed_entries? %>
-      <%= link_to 'Export Errored Entries', importer_export_errors_path(@importer.id), class: 'btn btn-primary', data: { turbolinks: false }%>
-      <%= link_to 'Upload Corrected Entries', importer_upload_corrected_entries_path(@importer.id), class: 'btn btn-primary' if @importer.parser.is_a?(Bulkrax::CsvParser) %>
+      <%= link_to 'Export Errored Entries', importer_export_errors_path(@importer.id), class: 'btn btn-primary text-nowrap', data: { turbolinks: false }%>
+      <%= link_to 'Upload Corrected Entries', importer_upload_corrected_entries_path(@importer.id), class: 'btn btn-primary text-nowrap' if @importer.parser.is_a?(Bulkrax::CsvParser) %>
     <% end %>
   </div>
 </div>

--- a/app/views/bulkrax/shared/_entries_tab.html.erb
+++ b/app/views/bulkrax/shared/_entries_tab.html.erb
@@ -12,5 +12,5 @@
       </tr>
     </thead>
   </table>
-  <div id='importer-entry-classes' class='hidden'><%= [item.parser.entry_class.to_s, item.parser.collection_entry_class.to_s, item.parser.file_set_entry_class.to_s].compact.join('|') %></div>
+  <div id='importer-entry-classes' class='hidden d-none'><%= [item.parser.entry_class.to_s, item.parser.collection_entry_class.to_s, item.parser.file_set_entry_class.to_s].compact.join('|') %></div>
 </div>

--- a/config/locales/bulkrax.en.yml
+++ b/config/locales/bulkrax.en.yml
@@ -1,9 +1,9 @@
 en:
-  helpers: 
-    action: 
+  helpers:
+    action:
       importer:
         new: "New"
-      exporter: 
+      exporter:
         new: "New"
   bulkrax:
     admin:
@@ -75,6 +75,8 @@ en:
         identifier: Identifier
         entry_id: Entry ID
         status: Status
+        type: Type
+        updated_at: Updated At
         errors: Errors
         status_set_at: Status Set At
         actions: Actions


### PR DESCRIPTION
## 🐛 Cleaning up UI on importers show

4fb1a9a9bc3828f4e44395029ba9d89392f2bd96

This commit will align the download buttons on the importer pages with
the header.  Also, the table width was funky so that is also fixed.

### Before:
https://github.com/user-attachments/assets/e6f21af9-00f5-46f3-a5d2-fec0759832be

### After:
https://github.com/user-attachments/assets/a1c9edc2-26cf-4e0e-834a-5ce969d73fdd

## Add missing translations

786fb464a3e140825ce99bad92c68043c907c427

This commit will add missing translations for the importer show page
table.

<img width="1417" alt="image" src="https://github.com/user-attachments/assets/f89ef349-7659-4da1-b303-8e16c95baad3" />

## Hide importer-entry-classes div

8ff8d77fa6a480dcca5c989df170f560167cc466

In Bootstrap 4 we now use d-none.

<img width="1423" alt="image" src="https://github.com/user-attachments/assets/cf71847b-992c-485f-b311-04351c25391e" />
