### PR TITLE
:bug: Fix CSV file path handling in zip imports

### DIFF
--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -379,7 +379,10 @@ module Bulkrax
     # We expect a single CSV at the top level of the zip in the CSVParser
     # but we are willing to go look for it if need be
     def real_import_file_path
-      return Dir["#{importer_unzip_path}/**/*.csv"].reject { |path| in_files_dir?(path) }.first if file? && zip?
+      if file? && zip?
+        csv_files = Dir["#{importer_unzip_path}/**/*.csv"].reject { |path| in_files_dir?(path) }
+        return csv_files.first if csv_files.any?
+      end
 
       parser_fields['import_file_path']
     end


### PR DESCRIPTION
When re running a single entry, a nil file path was getting sent to #read_data and thus resulted in the StandardError.

The issue is in #real_import_file_path where we're returning too early when file? && zip? is true but no CSV files are found in the unzipped directory.