### PR TITLE
🐛 Fix `#importer_unzip_path` logic

### DIFF
--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -237,9 +237,9 @@ module Bulkrax
     # end
 
     # If the import data is zipped, unzip it to this path
-    def importer_unzip_path
+    def importer_unzip_path(mkdir: false)
       @importer_unzip_path ||= File.join(parser.base_path, "import_#{path_string}")
-      return @importer_unzip_path if Dir.exist?(@importer_unzip_path)
+      return @importer_unzip_path if Dir.exist?(@importer_unzip_path) || mkdir == true
 
       # turns "tmp/imports/tenant/import_1_20250122035229_1" to "tmp/imports/tenant/import_1_20250122035229"
       base_importer_unzip_path = @importer_unzip_path.split('_')[0...-1].join('_')

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -432,7 +432,7 @@ module Bulkrax
 
       Zip::File.open(file_to_unzip) do |zip_file|
         zip_file.each do |entry|
-          entry_path = File.join(importer_unzip_path, entry.name)
+          entry_path = File.join(importer_unzip_path(mkdir: true), entry.name)
           FileUtils.mkdir_p(File.dirname(entry_path))
           zip_file.extract(entry, entry_path) unless File.exist?(entry_path)
         end
@@ -440,7 +440,7 @@ module Bulkrax
     end
 
     def untar(file_to_untar)
-      Dir.mkdir(importer_unzip_path) unless File.directory?(importer_unzip_path)
+      Dir.mkdir(importer_unzip_path(mkdir: true)) unless File.directory?(importer_unzip_path)
       command = "tar -xzf #{Shellwords.escape(file_to_untar)} -C #{Shellwords.escape(importer_unzip_path)}"
       result = system(command)
       raise "Failed to extract #{file_to_untar}" unless result


### PR DESCRIPTION
We discovered a bug with the previous updates to
the `#importer_unzip_path` method where when the method is being called to create a path, it returns `nil` because the path does not exist and the whole reason why we are calling the method is to create the path.

We add a `mkdir` argument to differentiate between when we're looking up the path vs wanting to create it.