### PR TITLE
Bulkrax should show errors when remote urls are not valid 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ else
 end
 
 gem 'oai'
+gem 'pg'
 gem 'rsolr', '>= 1.0'
 gem 'rspec-rails'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -433,7 +433,6 @@ module Bulkrax
       remote_files.map do |r|
         file_path = download_file(r["url"])
         next unless file_path
-
         create_uploaded_file(file_path, r["file_name"])
       end.compact
     end
@@ -449,8 +448,7 @@ module Bulkrax
         file.rewind
         file.path
       rescue => e
-        Rails.logger.debug "Failed to download file from #{url}: #{e.message}"
-        nil
+        raise "Failed to download file from #{url}: #{e.message}"
       end
     end
 
@@ -460,8 +458,7 @@ module Bulkrax
       file.close
       uploaded_file
     rescue => e
-      Rails.logger.debug "Failed to create Hyrax::UploadedFile for #{file_name}: #{e.message}"
-      nil
+      raise "Failed to create Hyrax::UploadedFile for #{file_name}: #{e.message}"
     end
 
     # @Override Destroy existing files with Hyrax::Transactions


### PR DESCRIPTION
## Summary
Bulkrax jobs were continuing without reporting an error, with nothing appearing in the logs.

This commit causes file errors to be reported in the importer even though the job will end normally.

## Screenshots

<details>
![screencapture-cat-adl-test-importers-2025-02-07-15_27_32](https://github.com/user-attachments/assets/38e22306-6705-459a-b0de-3f7b09f05492)

![screencapture-cat-adl-test-importers-4-2025-02-07-15_25_33](https://github.com/user-attachments/assets/10bc76a1-d960-4015-b00a-dbe4cecd9e83)

![screencapture-cat-adl-test-importers-4-entries-127-2025-02-07-15_25_53](https://github.com/user-attachments/assets/d44f4ab0-64fa-4334-b56c-7376a04af109)


</details>


