### PR TITLE
pass mkdir when first referencing unzip path in `#untar`

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -440,7 +440,7 @@ module Bulkrax
     end
 
     def untar(file_to_untar)
-      Dir.mkdir(importer_unzip_path(mkdir: true)) unless File.directory?(importer_unzip_path)
+      Dir.mkdir(importer_unzip_path) unless File.directory?(importer_unzip_path(mkdir: true))
       command = "tar -xzf #{Shellwords.escape(file_to_untar)} -C #{Shellwords.escape(importer_unzip_path)}"
       result = system(command)
       raise "Failed to extract #{file_to_untar}" unless result


### PR DESCRIPTION
This fixes a bug where `File.directory?` was being called on `nil` because the unless statement was running before the `Dir.mkdir` statement, which was supposed to create the new dir