### PR TITLE
re-fix `#untar` to correctly create dir

### DIFF
--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -440,7 +440,7 @@ module Bulkrax
     end
 
     def untar(file_to_untar)
-      Dir.mkdir(importer_unzip_path) unless File.directory?(importer_unzip_path(mkdir: true))
+      Dir.mkdir(importer_unzip_path(mkdir: true)) unless File.directory?(importer_unzip_path(mkdir: true))
       command = "tar -xzf #{Shellwords.escape(file_to_untar)} -C #{Shellwords.escape(importer_unzip_path)}"
       result = system(command)
       raise "Failed to extract #{file_to_untar}" unless result


### PR DESCRIPTION
I got a false positive when testing this locally for #1018, the `mkdir` flag is needed for both `importer_unzip_path` invocations