### PR TITLE
Replace spaces with underscores in filenames

### DIFF
--- a/app/jobs/bulkrax/importer_job.rb
+++ b/app/jobs/bulkrax/importer_job.rb
@@ -30,6 +30,7 @@ module Bulkrax
       return unless parser.file? && parser.zip?
 
       parser.unzip(parser.parser_fields['import_file_path'])
+      parser.remove_spaces_from_filenames
     end
 
     def update_current_run_counters(importer)

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -446,6 +446,21 @@ module Bulkrax
       raise "Failed to extract #{file_to_untar}" unless result
     end
 
+    # File names referenced in CSVs have spaces replaced with underscores
+    # @see Bulkrax::CsvParser#file_paths
+    def remove_spaces_from_filenames
+      files = Dir.glob(File.join(importer_unzip_path, 'files', '*'))
+      files_with_spaces = files.select { |f| f.split('/').last.match?(' ') }
+      return if files_with_spaces.blank?
+
+      files_with_spaces.map! { |path| Pathname.new(path) }
+      files_with_spaces.each do |path|
+        filename = path.basename
+        filename_without_spaces = filename.to_s.tr(' ', '_')
+        path.rename(File.join(path.dirname, filename_without_spaces))
+      end
+    end
+
     def zip
       FileUtils.mkdir_p(exporter_export_zip_path)
 


### PR DESCRIPTION
When imported metadata is parsed, filenames containing spaces have those spaces replaced with underscores. Before this commit, this would cause the entire importer to fail since the importer thought it didn't have the file at all ("file name.jpg" != "file_name.jpg"). If we're coercing the metadata, it only makes sense to coerce the filenames as well