### PR TITLE
Bulkrax editing without model

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -91,7 +91,7 @@ module Bulkrax
     # @note HEY WE'RE USING THIS FOR A WINGS CUSTOM QUERY.  BE CAREFUL WITH
     #       REMOVING IT.
     #
-    # @see # {Wings::CustomQueries::FindBySourceIdentifier#find_by_model_and_property_value}
+    # @see # {Wings::CustomQueries::FindBySourceIdentifier#find_by_property_value}
     def self.search_by_property(value:, klass:, field: nil, search_field: nil, name_field: nil, verify_property: false)
       return nil unless klass.respond_to?(:where)
       # We're not going to try to match nil nor "".

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -179,7 +179,7 @@ module Bulkrax
       raise "Expected named_field or field got nil" if name_field.blank?
       return if value.blank?
       # Return nil or a single object.
-      Hyrax.query_service.custom_queries.find_by_property_value(property: name_field, value:, search_field:)
+      Hyrax.query_service.custom_queries.find_by_property_value(property: name_field, value: value, search_field: search_field)
     end
     # rubocop:enable Metrics/ParameterLists
 

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -174,13 +174,12 @@ module Bulkrax
     # @return [Valkyrie::Resource] when a match is found, an instance of given
     #         :klass
     # rubocop:disable Metrics/ParameterLists
-    def self.search_by_property(value:, klass:, field: nil, name_field: nil, **)
+    def self.search_by_property(value:, field: nil, name_field: nil, search_field:, **)
       name_field ||= field
       raise "Expected named_field or field got nil" if name_field.blank?
       return if value.blank?
-
       # Return nil or a single object.
-      Hyrax.query_service.custom_query.find_by_model_and_property_value(model: klass, property: name_field, value: value)
+      Hyrax.query_service.custom_queries.find_by_property_value(property: name_field, value:, search_field:)
     end
     # rubocop:enable Metrics/ParameterLists
 

--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -16,8 +16,9 @@ module Bulkrax
 
     def result(_parser, content)
       return nil if self.excluded == true || Bulkrax.reserved_properties.include?(self.to)
+      # rubocop:disable Style/RedundantParentheses
       return nil if self.if && (!self.if.is_a?(Array) && self.if.length != 2)
-
+      # rubocop:enable Style/RedundantParentheses
       if self.if
         return unless content.send(self.if[0], Regexp.new(self.if[1]))
       end

--- a/app/services/hyrax/custom_queries/find_by_source_identifier.rb
+++ b/app/services/hyrax/custom_queries/find_by_source_identifier.rb
@@ -6,7 +6,7 @@ module Hyrax
     # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
     class FindBySourceIdentifier
       def self.queries
-        [:find_by_model_and_property_value]
+        [:find_by_property_value]
       end
 
       def initialize(query_service:)
@@ -18,30 +18,25 @@ module Hyrax
       delegate :orm_class, to: :resource_factory
 
       ##
-      # @param model [Class, #internal_resource]
       # @param property [#to_s] the name of the property we're attempting to
       #        query.
       # @param value [#to_s] the propety's value that we're trying to match.
       #
       # @return [NilClass] when no record was found
       # @return [Valkyrie::Resource] when a record was found
-      #
-      # @note This is not a real estate transaction nor a Zillow lookup.
-      def find_by_model_and_property_value(model:, property:, value:)
-        sql_query = sql_for_find_by_model_and_property_value
-        # NOTE: Do we need to ask the model for it's internal_resource?
-        # TODO: no => undefined method `internal_resource' for Image:Class
-        query_service.run_query(sql_query, model, property, value).first
+      def find_by_property_value(property:, value:, **)
+        sql_query = sql_for_find_by_property_value
+        query_service.run_query(sql_query, property, value.to_s).first
       end
 
       private
 
-      def sql_for_find_by_model_and_property_value
+      def sql_for_find_by_property_value
         # NOTE: This is querying the first element of the property, but we might
         # want to check all of the elements.
         <<-SQL
           SELECT * FROM orm_resources
-          WHERE internal_resource = ? AND metadata -> ? ->> 0 = ?
+          WHERE metadata -> ? ->> 0 = ?
           LIMIT 1;
         SQL
       end

--- a/app/services/wings/custom_queries/find_by_source_identifier.rb
+++ b/app/services/wings/custom_queries/find_by_source_identifier.rb
@@ -16,7 +16,9 @@ module Wings
         @query_service = query_service
       end
 
+      # rubocop:disable Lint/UnusedMethodArgument
       def find_by_property_value(property:, value:, search_field:, use_valkyrie: Hyrax.config.use_valkyrie?)
+        # rubocop:enable Lint/UnusedMethodArgument
         # NOTE: This is using the Bulkrax::ObjectFactory (e.g. the one envisioned for ActiveFedora).
         # In doing this, we avoid the situation where Bulkrax::ValkyrieObjectFactory calls this custom query.
 

--- a/app/services/wings/custom_queries/find_by_source_identifier.rb
+++ b/app/services/wings/custom_queries/find_by_source_identifier.rb
@@ -6,7 +6,7 @@ module Wings
       # Custom query override specific to Wings
 
       def self.queries
-        [:find_by_model_and_property_value]
+        [:find_by_property_value]
       end
 
       attr_reader :query_service
@@ -16,11 +16,12 @@ module Wings
         @query_service = query_service
       end
 
-      def find_by_model_and_property_value(model:, property:, value:, use_valkyrie: Hyrax.config.use_valkyrie?)
-        # NOTE: This is using the Bulkrax::ObjectFactory (e.g. the one
-        # envisioned for ActiveFedora).  In doing this, we avoid the situation
-        # where Bulkrax::ValkyrieObjectFactory calls this custom query.
-        af_object = Bulkrax::ObjectFactory.search_by_property(value: value, klass: model, field: property)
+      def find_by_property_value(property:, value:, search_field:, use_valkyrie: Hyrax.config.use_valkyrie?)
+        # NOTE: This is using the Bulkrax::ObjectFactory (e.g. the one envisioned for ActiveFedora).
+        # In doing this, we avoid the situation where Bulkrax::ValkyrieObjectFactory calls this custom query.
+
+        # This is doing a solr search so we have to use the search_field instead of the property
+        af_object = Bulkrax::ObjectFactory.search_by_property(value: value, klass: ActiveFedora::Base, field: search_field)
 
         return if af_object.blank?
         return af_object unless use_valkyrie

--- a/app/views/bulkrax/entries/show.html.erb
+++ b/app/views/bulkrax/entries/show.html.erb
@@ -33,14 +33,16 @@
 
     <p class='bulkrax-p-align'>
       <% if @importer.present? %>
-	<%# TODO Consider how to account for Bulkrax.collection_model_class %>
+	    <%# TODO Consider how to account for Bulkrax.collection_model_class %>
         <% factory_record = @entry.factory.find %>
-        <% if factory_record.present? && @entry.factory_class %>
-          <strong><%= @entry.factory_class.model_name.human %> Link:</strong>
-          <% if defined?(Hyrax) && @entry.factory_class.model_name.human == 'Collection' %>
-            <%= link_to @entry.factory_class.model_name.human, hyrax.polymorphic_path(factory_record) %>
+        <% if factory_record.present? %>
+          <% factory_record_class = factory_record.class %>
+          <% factory_record_class_human = factory_record_class.model_name.human %>
+          <strong><%= factory_record_class_human %> Link:</strong>
+          <% if defined?(Hyrax) && factory_record_class_human == 'Collection' %>
+            <%= link_to factory_record_class_human, hyrax.polymorphic_path(factory_record) %>
           <% else %>
-            <%= link_to @entry.factory_class.model_name.human, main_app.polymorphic_path(factory_record) %>
+            <%= link_to factory_record_class_human, main_app.polymorphic_path(factory_record) %>
           <% end %>
         <% else %>
           <strong>Item Link:</strong> Item has not yet been imported successfully

--- a/lib/bulkrax/engine.rb
+++ b/lib/bulkrax/engine.rb
@@ -35,7 +35,7 @@ module Bulkrax
         ActionController::Base.view_paths = paths.uniq
 
         custom_query_strategies = {
-          find_by_model_and_property_value: :find_single_or_nil
+          find_by_property_value: :find_single_or_nil
         }
 
         if defined?(::Goddess::CustomQueryContainer)


### PR DESCRIPTION
# Summary

https://github.com/samvera/bulkrax/issues/1024

This commit allows a CSV importer edit to find the object to edit by the identifier rather than requiring the class. 

# Behavior before change

If a CSV did not include the model, the edit would create new valkyrie works using the defined default model. This resulted in two works in the resource table, with only the newer one indexed. The new work would only contain the metadata present in the edit CSV. The prior work was left untouched.

# Behavior after change

The source identifier alone is adequate to find the object to edit, and the importer view shows the correct model name when it links to the edited object.

(Note that it still shows the default type above the raw and parsed metadata)

<details>
<summary>Screenshot</summary>

![Screenshot 2025-04-04 at 3 46 07 PM](https://github.com/user-attachments/assets/cd5fa4dc-eea7-4d1f-930f-2d972c829935)

</details>