### PR TITLE
Fix relationship race condition

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -66,6 +66,7 @@ module Bulkrax
     # saving it with each child, but waiting until the end to reindex.
     # To do this we are bypassing the save! method defined below
     def self.add_child_to_parent_work(parent:, child:)
+      parent = self.find(parent.id)
       return true if parent.member_ids.include?(child.id)
       parent.member_ids << child.id
       Hyrax.persister.save(resource: parent)

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -125,6 +125,8 @@ module Bulkrax
     end
 
     def self.publish(event:, **kwargs)
+      # It's a bit unclear what this should be if we can't rely on Hyrax.
+      raise NotImplementedError, "#{self}.#{__method__}" unless defined?(Hyrax)
       Hyrax.publisher.publish(event, **kwargs)
     end
 
@@ -142,9 +144,9 @@ module Bulkrax
         raise Valkyrie::Persistence::ObjectNotFoundError unless result
         Hyrax.index_adapter.save(resource: result)
         if result.collection?
-          publish('collection.metadata.updated', collection: result, user: user)
+          self.publish(event: 'collection.metadata.updated', collection: result, user: user)
         else
-          publish('object.metadata.updated', object: result, user: user)
+          self.publish(event: 'object.metadata.updated', object: result, user: user)
         end
       else
         resource.save!
@@ -209,7 +211,7 @@ module Bulkrax
 
       Hyrax.persister.delete(resource: obj)
       Hyrax.index_adapter.delete(resource: obj)
-      self.class.publish(event: 'object.deleted', object: obj, user: user)
+      self.publish(event: 'object.deleted', object: obj, user: user)
     end
 
     def run!
@@ -228,7 +230,7 @@ module Bulkrax
 
       @object.depositor = @user.email
       object = Hyrax.persister.save(resource: @object)
-      self.class.publish(event: "object.metadata.updated", object: object, user: @user)
+      self.publish(event: "object.metadata.updated", object: object, user: @user)
       object
     end
 

--- a/spec/factories/bulkrax/pending_relationships.rb
+++ b/spec/factories/bulkrax/pending_relationships.rb
@@ -1,27 +1,38 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :pending_relationship, class: 'Bulkrax::PendingRelationship' do
+    association :importer_run, factory: :bulkrax_importer_run
+    parent_id { 'entry_collection' }
+    child_id { 'entry_work' }
+    order { 1 }
+  end
+
   factory :pending_relationship_collection_parent, class: 'Bulkrax::PendingRelationship' do
     association :importer_run, factory: :bulkrax_importer_run
     parent_id { 'entry_collection' }
     child_id { 'entry_work' }
+    order { 1 }
   end
 
   factory :pending_relationship_collection_child, class: 'Bulkrax::PendingRelationship' do
     association :importer_run, factory: :bulkrax_importer_run
     parent_id { 'parent_entry_collection' }
     child_id { 'child_entry_collection' }
+    order { 1 }
   end
 
   factory :pending_relationship_work_parent, class: 'Bulkrax::PendingRelationship' do
     association :importer_run, factory: :bulkrax_importer_run
     parent_id { 'parent_entry_work' }
     child_id { 'child_entry_work' }
+    order { 1 }
   end
 
   factory :bad_pending_relationship, class: 'Bulkrax::PendingRelationship' do
     association :importer_run, factory: :bulkrax_importer_run
     parent_id { 'entry_work' }
     child_id { 'entry_collection' }
+    order { 1 }
   end
 end

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -54,11 +54,13 @@ module Bulkrax
       end
 
       context 'when adding a child work to a parent collection' do
-        let(:pending_rel_test) { create(:pending_relationship,
-                                        importer_run_id: importer.current_run.id,
-                                        parent_id: parent_identifier,
-                                        child_id: work1_entry.identifier,
-                                        order: 1) }
+        let(:pending_rel_test) do
+          create(:pending_relationship,
+                 importer_run_id: importer.current_run.id,
+                 parent_id: parent_identifier,
+                 child_id: work1_entry.identifier,
+                 order: 1)
+        end
         let(:parent_identifier) { collection1_entry.identifier }
 
         before do
@@ -86,11 +88,13 @@ module Bulkrax
       end
 
       context 'when adding a child collection to a parent collection' do
-        let(:pending_rel_test) { create(:pending_relationship,
-                                        importer_run_id: importer.current_run.id,
-                                        parent_id: parent_identifier,
-                                        child_id: collection2_entry.identifier,
-                                        order: 1) }
+        let(:pending_rel_test) do
+          create(:pending_relationship,
+                 importer_run_id: importer.current_run.id,
+                 parent_id: parent_identifier,
+                 child_id: collection2_entry.identifier,
+                 order: 1)
+        end
         let(:parent_identifier) { collection1_entry.identifier }
 
         before do
@@ -118,11 +122,13 @@ module Bulkrax
       end
 
       context 'when adding a child work to a parent work' do
-        let(:pending_rel_test) { create(:pending_relationship,
-                                        importer_run_id: importer.current_run.id,
-                                        parent_id: parent_identifier,
-                                        child_id: work2_entry.identifier,
-                                        order: 1) }
+        let(:pending_rel_test) do
+          create(:pending_relationship,
+                 importer_run_id: importer.current_run.id,
+                 parent_id: parent_identifier,
+                 child_id: work2_entry.identifier,
+                 order: 1)
+        end
         let(:parent_identifier) { work1_entry.identifier }
         let(:update_child_records_works_file_sets?) { false }
 
@@ -151,11 +157,13 @@ module Bulkrax
       end
 
       context 'when adding a child collection to a parent work' do
-        let(:pending_rel_test) { create(:pending_relationship,
-                                        importer_run_id: importer.current_run.id,
-                                        parent_id: parent_identifier,
-                                        child_id: collection1_entry.identifier,
-                                        order: 1) }
+        let(:pending_rel_test) do
+          create(:pending_relationship,
+                 importer_run_id: importer.current_run.id,
+                 parent_id: parent_identifier,
+                 child_id: collection1_entry.identifier,
+                 order: 1)
+        end
         let(:parent_identifier) { work1_entry.identifier }
 
         before do
@@ -175,18 +183,20 @@ module Bulkrax
       end
 
       context 'when adding a child record that is not found' do
-        let(:pending_rel_test) { create(:pending_relationship,
-                                        importer_run_id: importer.current_run.id,
-                                        parent_id: parent_identifier,
-                                        child_id: child_id,
-                                        order: 1) }
+        let(:pending_rel_test) do
+          create(:pending_relationship,
+                 importer_run_id: importer.current_run.id,
+                 parent_id: parent_identifier,
+                 child_id: child_id,
+                 order: 1)
+        end
         let(:parent_identifier) { collection1_entry.identifier }
         let(:child_id) { 'not_found' }
 
         before do
-        allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([work1_entry, work1])
-        allow(create_relationships_job).to receive(:find_record).with(child_id, importer.current_run.id).and_return([nil, nil])
-        pending_rel_test
+          allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([work1_entry, work1])
+          allow(create_relationships_job).to receive(:find_record).with(child_id, importer.current_run.id).and_return([nil, nil])
+          pending_rel_test
         end
 
         it 'reschedules the job' do
@@ -199,18 +209,20 @@ module Bulkrax
       end
 
       context 'when adding a parent record that is not found' do
-        let(:pending_rel_test) { create(:pending_relationship,
-                                        importer_run_id: importer.current_run.id,
-                                        parent_id: parent_identifier,
-                                        child_id: child_id,
-                                        order: 1) }
+        let(:pending_rel_test) do
+          create(:pending_relationship,
+                 importer_run_id: importer.current_run.id,
+                 parent_id: parent_identifier,
+                 child_id: child_id,
+                 order: 1)
+        end
         let(:parent_identifier) { 'not_found' }
         let(:child_id) { work1_entry.identifier }
 
         before do
-        allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([nil, nil])
-        allow(create_relationships_job).to receive(:find_record).with(child_id, importer.current_run.id).and_return([work1_entry, work1])
-        pending_rel_test
+          allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([nil, nil])
+          allow(create_relationships_job).to receive(:find_record).with(child_id, importer.current_run.id).and_return([work1_entry, work1])
+          pending_rel_test
         end
 
         it 'reschedules the job' do

--- a/spec/jobs/bulkrax/create_relationships_job_spec.rb
+++ b/spec/jobs/bulkrax/create_relationships_job_spec.rb
@@ -2,49 +2,43 @@
 
 require 'rails_helper'
 
-# Dear maintainer and code reader.  This spec stubs and mocks far too many
-# things to be immediately effective.  Why?  Because we don't have a functional
-# test object factory and data model.
-#
-# Because of this and a significant refactor of the object model; namely that we
-# moved to a repository pattern where we tell the repository to perform the
-# various commands instead of commands directly on the object.  This moved to a
-# repository pattern is necessitated by the shift from Hyrax's ActiveFedora
-# usage to Hyrax's Valkyrie uses.
 module Bulkrax
   RSpec.describe CreateRelationshipsJob, type: :job do
     let(:create_relationships_job) { described_class.new }
     let(:importer) { FactoryBot.create(:bulkrax_importer_csv_complex) }
-    let(:parent_entry) { create(:bulkrax_csv_entry_collection, importerexporter: importer) }
-    let(:child_entry) { create(:bulkrax_csv_entry_work, importerexporter: importer) }
-    let(:parent_record) { build(:collection) }
-    let(:child_record) { build(:work) }
-    let(:pending_rel) { create(:pending_relationship_collection_parent, importer_run: importer.current_run, parent_id: parent_id, child_id: child_id) }
-    let(:pending_rel_work) { build(:pending_relationship_work_parent) }
-    let(:parent_id) { parent_entry.identifier }
-    let(:child_id) { child_entry.identifier }
+    let(:ability) { instance_double(Ability) }
+
+    # create objects
+    let(:collection1) { build(:collection) }
+    let(:collection2) { build(:collection) }
+    let(:work1) { build(:work) }
+    let(:work2) { build(:work) }
+
+    # create entries
+    let(:collection1_entry) { create(:bulkrax_csv_entry_collection, importerexporter: importer) }
+    let(:collection2_entry) { create(:bulkrax_csv_entry_collection, importerexporter: importer) }
+    let(:work1_entry) { create(:bulkrax_csv_entry_work, importerexporter: importer) }
+    let(:work2_entry) { create(:bulkrax_csv_entry_work, importerexporter: importer) }
+
+    before do
+      allow(ImporterRun).to receive(:update_counters).and_return(true)
+      allow(Ability).to receive(:new).and_return(ability)
+      allow(ability).to receive(:authorize!).and_return(true)
+      # The real work happens in the object factory. Each object factory
+      # should have its own tests to verify that it does the right thing.
+      allow(Bulkrax.object_factory).to receive(:add_resource_to_collection).and_return(true)
+      allow(Bulkrax.object_factory).to receive(:update_index).and_return(true)
+      allow(Bulkrax.object_factory).to receive(:publish).and_return(true)
+      allow(create_relationships_job).to receive(:reschedule)
+      allow(Bulkrax.object_factory).to receive(:add_child_to_parent_work).and_return(true)
+      allow(Bulkrax.object_factory).to receive(:save!).and_return(true)
+    end
 
     around do |spec|
       old = Bulkrax.object_factory
       Bulkrax.object_factory = Bulkrax::MockObjectFactory
       spec.run
       Bulkrax.object_factory = old
-    end
-    before do
-      allow_any_instance_of(Ability).to receive(:authorize!).and_return(true)
-
-      allow(create_relationships_job).to receive(:reschedule)
-      allow(::Hyrax.config).to receive(:curation_concerns).and_return([Work])
-      allow(Bulkrax::MockObjectFactory).to receive(:save!).and_return(true)
-      allow(child_record).to receive(:update_index)
-      allow(child_record).to receive(:member_of_collections).and_return([])
-      allow(parent_record).to receive(:ordered_members).and_return([])
-
-      allow(create_relationships_job).to receive(:find_record)
-      allow(create_relationships_job).to receive(:find_record).with(parent_id, importer.current_run.id).and_return([parent_entry, parent_record])
-      allow(create_relationships_job).to receive(:find_record).with(child_id, importer.current_run.id).and_return([child_entry, child_record])
-
-      pending_rel
     end
 
     describe 'is capable of looking up records dynamically' do
@@ -54,20 +48,31 @@ module Bulkrax
     describe '#perform' do
       subject(:perform) do
         create_relationships_job.perform(
-          parent_identifier: parent_id, # source_identifier
+          parent_identifier: parent_identifier, # source_identifier
           importer_run_id: importer.current_run.id
         )
       end
 
-      xcontext 'when adding a child work to a parent collection' do
-        before { allow(child_record).to receive(:file_sets).and_return([]) }
+      context 'when adding a child work to a parent collection' do
+        let(:pending_rel_test) { create(:pending_relationship,
+                                        importer_run_id: importer.current_run.id,
+                                        parent_id: parent_identifier,
+                                        child_id: work1_entry.identifier,
+                                        order: 1) }
+        let(:parent_identifier) { collection1_entry.identifier }
 
-        it 'assigns the parent to the child\'s #member_of_collections' do
-          expect { perform }.to change(child_record, :member_of_collections).from([]).to([parent_record])
+        before do
+          allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([collection1_entry, collection1])
+          allow(create_relationships_job).to receive(:find_record).with(work1_entry.identifier, importer.current_run.id).and_return([work1_entry, work1])
+          pending_rel_test
         end
 
-        it 'increments the processed relationships counter on the importer run' do
-          expect { perform }.to change { importer.current_run.reload.processed_relationships }.by(1)
+        it 'calls the object factory to assign the child work to the collection' do
+          expect(Bulkrax.object_factory).to receive(:add_resource_to_collection).with(collection: collection1, resource: work1, user: importer.current_run.user)
+          expect(Bulkrax.object_factory).to receive(:update_index).with(resources: [collection1])
+          expect(Bulkrax.object_factory).to receive(:publish).with(event: 'object.membership.updated', object: collection1, user: importer.current_run.user)
+          expect(ImporterRun).to receive(:update_counters).with(importer.current_run.id, processed_relationships: 1)
+          perform
         end
 
         it 'deletes the pending relationship' do
@@ -80,16 +85,26 @@ module Bulkrax
         end
       end
 
-      xcontext 'when adding a child collection to a parent collection' do
-        let(:child_record) { build(:another_collection) }
-        let(:child_entry) { create(:bulkrax_csv_another_entry_collection, importerexporter: importer) }
+      context 'when adding a child collection to a parent collection' do
+        let(:pending_rel_test) { create(:pending_relationship,
+                                        importer_run_id: importer.current_run.id,
+                                        parent_id: parent_identifier,
+                                        child_id: collection2_entry.identifier,
+                                        order: 1) }
+        let(:parent_identifier) { collection1_entry.identifier }
 
-        it 'assigns the parent to the child\'s #member_of_collections' do
-          expect { perform }.to change(child_record, :member_of_collections).from([]).to([parent_record])
+        before do
+          allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([collection1_entry, collection1])
+          allow(create_relationships_job).to receive(:find_record).with(work1_entry.identifier, importer.current_run.id).and_return([collection2_entry, collection2])
+          pending_rel_test
         end
 
-        it 'increments the processed relationships counter on the importer run' do
-          expect { perform }.to change { importer.current_run.reload.processed_relationships }.by(1)
+        it 'calls the object factory to assign the child collection to the collection' do
+          expect(Bulkrax.object_factory).to receive(:add_resource_to_collection).with(collection: collection1, resource: collection2, user: importer.current_run.user)
+          expect(Bulkrax.object_factory).to receive(:update_index).with(resources: [collection1])
+          expect(Bulkrax.object_factory).to receive(:publish).with(event: 'object.membership.updated', object: collection1, user: importer.current_run.user)
+          expect(ImporterRun).to receive(:update_counters).with(importer.current_run.id, processed_relationships: 1)
+          perform
         end
 
         it 'deletes the pending relationship' do
@@ -100,61 +115,109 @@ module Bulkrax
           perform
           expect(create_relationships_job).not_to have_received(:reschedule)
         end
-
-        # TODO: Do we need to account for this because of Hyrax 2.9.x implementations?
-        xit 'runs NestedCollectionPersistenceService'
       end
 
-      xcontext 'when adding a child work to a parent work' do
-        let(:parent_record) { build(:another_work) }
-        let(:parent_entry) { create(:bulkrax_csv_entry_work, identifier: "other_identifier", importerexporter: importer) }
+      context 'when adding a child work to a parent work' do
+        let(:pending_rel_test) { create(:pending_relationship,
+                                        importer_run_id: importer.current_run.id,
+                                        parent_id: parent_identifier,
+                                        child_id: work2_entry.identifier,
+                                        order: 1) }
+        let(:parent_identifier) { work1_entry.identifier }
+        let(:update_child_records_works_file_sets?) { false }
 
-        it 'assigns the child to the parent\'s #ordered_members' do
-          expect { perform }.to change(parent_record, :ordered_members).from([]).to([child_record])
+        before do
+          allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([work1_entry, work1])
+          allow(create_relationships_job).to receive(:find_record).with(work2_entry.identifier, importer.current_run.id).and_return([work2_entry, work2])
+          pending_rel_test
         end
 
-        it 'reindexes the child work' do
+        it 'calls the object factory to assign the child work to the parent_work' do
+          expect(Bulkrax.object_factory).to receive(:add_child_to_parent_work).with(parent: work1, child: work2)
+          expect(Bulkrax.object_factory).to receive(:save!).with(resource: work1, user: importer.current_run.user)
+          expect(Bulkrax.object_factory).not_to receive(:update_index_for_file_sets_of)
+          expect(ImporterRun).to receive(:update_counters).with(importer.current_run.id, processed_relationships: 1)
           perform
-          expect(child_record).to have_received(:update_index)
-        end
-
-        it 'increments the processed relationships counter on the importer run' do
-          expect { perform }.to change { importer.current_run.reload.processed_relationships }.by(1)
         end
 
         it 'deletes the pending relationship' do
           expect { perform }.to change(Bulkrax::PendingRelationship, :count).by(-1)
         end
+
+        it 'does not reschedule the job' do
+          perform
+          expect(create_relationships_job).not_to have_received(:reschedule)
+        end
       end
 
-      xcontext 'when adding a child collection to a parent work' do
-        let(:child_entry) { create(:bulkrax_csv_entry_collection, importerexporter: importer) }
-        let(:parent_entry) { create(:bulkrax_csv_entry_work, importerexporter: importer) }
-        let(:child_record) { build(:collection) }
-        let(:parent_record) { build(:work) }
+      context 'when adding a child collection to a parent work' do
+        let(:pending_rel_test) { create(:pending_relationship,
+                                        importer_run_id: importer.current_run.id,
+                                        parent_id: parent_identifier,
+                                        child_id: collection1_entry.identifier,
+                                        order: 1) }
+        let(:parent_identifier) { work1_entry.identifier }
+
+        before do
+          allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([work1_entry, work1])
+          allow(create_relationships_job).to receive(:find_record).with(collection1_entry.identifier, importer.current_run.id).and_return([collection1_entry, collection1])
+          pending_rel_test
+        end
 
         it 'logs an error to the parent entry' do
-          expect { perform }.to change(parent_entry, :failed?).to(true)
+          expect { perform }.to change(work1_entry, :failed?).to(true)
         end
 
         it 'increments current importer run\'s :failed_relationships' do
-          expect { perform }.to change { importer.current_run.reload.failed_relationships }.by(1)
-        end
-      end
-
-      xcontext 'when adding a child record that is not found' do
-        it 'reschudules the job' do
-          expect(create_relationships_job).to receive(:find_record).with(child_id, importer.current_run.id).and_return([nil, nil])
+          expect(ImporterRun).to receive(:update_counters).with(importer.current_run.id, failed_relationships: 1)
           perform
-          expect(create_relationships_job).to have_received(:reschedule).with(parent_identifier: parent_id, importer_run_id: importer.current_run.id)
         end
       end
 
-      xcontext 'when adding a parent record that is not found' do
+      context 'when adding a child record that is not found' do
+        let(:pending_rel_test) { create(:pending_relationship,
+                                        importer_run_id: importer.current_run.id,
+                                        parent_id: parent_identifier,
+                                        child_id: child_id,
+                                        order: 1) }
+        let(:parent_identifier) { collection1_entry.identifier }
+        let(:child_id) { 'not_found' }
+
+        before do
+        allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([work1_entry, work1])
+        allow(create_relationships_job).to receive(:find_record).with(child_id, importer.current_run.id).and_return([nil, nil])
+        pending_rel_test
+        end
+
         it 'reschedules the job' do
-          expect(create_relationships_job).to receive(:find_record).with(parent_id, importer.current_run.id).and_return([nil, nil])
-          perform
-          expect(create_relationships_job).to have_received(:reschedule).with(parent_identifier: parent_id, importer_run_id: importer.current_run.id)
+          expect(ImporterRun).to receive(:update_counters).with(importer.current_run.id, failed_relationships: 1)
+          expect(create_relationships_job).to receive(:reschedule).with(parent_identifier: parent_identifier, importer_run_id: importer.current_run.id, run_user: importer.current_run.user, failure_count: 1)
+          result = perform
+          # Expect the result to be an array containing one RuntimeError
+          expect(result).to match([an_instance_of(RuntimeError)])
+        end
+      end
+
+      context 'when adding a parent record that is not found' do
+        let(:pending_rel_test) { create(:pending_relationship,
+                                        importer_run_id: importer.current_run.id,
+                                        parent_id: parent_identifier,
+                                        child_id: child_id,
+                                        order: 1) }
+        let(:parent_identifier) { 'not_found' }
+        let(:child_id) { work1_entry.identifier }
+
+        before do
+        allow(create_relationships_job).to receive(:find_record).with(parent_identifier, importer.current_run.id).and_return([nil, nil])
+        allow(create_relationships_job).to receive(:find_record).with(child_id, importer.current_run.id).and_return([work1_entry, work1])
+        pending_rel_test
+        end
+
+        it 'reschedules the job' do
+          expect(ImporterRun).to receive(:update_counters).with(importer.current_run.id, failed_relationships: 1)
+          expect(create_relationships_job).to receive(:reschedule).with(parent_identifier: parent_identifier, importer_run_id: importer.current_run.id, run_user: importer.current_run.user, failure_count: 1)
+          result = perform
+          expect(result).to eq(["Parent record #{parent_identifier} not yet available for creating relationships with children records."])
         end
       end
     end


### PR DESCRIPTION
# Summary

https://github.com/samvera/bulkrax/issues/1027

Bug fixes:
- Refactor the `save!` method in the `valkyrie_object_factory` - the resources respond to save so they were being saved directly by calling save rather than by using the persister. This *should* behave the same way, since we include `Hyrax::ArResource`, but ideally `save` is a fallback, not the default.
- Corrects event notifications so events are sent and event jobs do not fail.
- Correct update of Bulkrax::PendingRelationship entry, setting with an appropriate error message. 
- Fixes finding of the child record to finding only within the given importer run.
- Refactors the CreateRelationshipsJob to lock child records when necessary, to ensure that concurrent jobs do not interfere with each other. However, the locking still seemed to not work correctly, so this PR also reloads the resources where necessary before applying changes & saving, to shorten risk of race errors.

# Notes

Remaining tasks:
- [ ] Figure out why locking doesn't work. This is not a blocker, because the job was changed to find the records prior to saving where necessary.

<details>
<summary>Screenshots</summary>

### Import with mixed types of parents
[import1.csv](https://github.com/user-attachments/files/20104578/import1.csv)

Three relationship jobs get submitted for the above CSV: COL1 as parent, COL2 as parent, and TAQ1 as parent. 

Prior to these changes, Work TAQ1 would always be missing at least one of its three relationships (2 as child of the collections, and 1 as parent to TAQ2). 

With these proposed changes, two collections and two works were added. Work TAQ1 was added to COL1 and COL2, and work TAQ2 was added to work TAQ1 and COL1. 

![Screenshot 2025-05-08 at 10 31 31 AM](https://github.com/user-attachments/assets/03239387-6490-43d7-baee-d262e63cf5ef)

![Screenshot 2025-05-08 at 10 31 50 AM](https://github.com/user-attachments/assets/f87d059e-ba7f-48c4-ab5f-a399da509951)
### Adding relationships to two collections at the same time
120 works were created in one import.
In a second import, two collections were created and associated to all 120 works. 

![Screenshot 2025-05-08 at 11 45 53 AM](https://github.com/user-attachments/assets/ca33a19e-0296-4412-bb70-1a0dac8aa3f0)


</details>
