### PR TITLE
🐛 [i41] - fix(ValkyrieObjectFactory): Prevent duplicate object creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,12 +18,9 @@ gem 'coderay'
 gem 'concurrent-ruby', '1.3.4'
 gem 'factory_bot_rails'
 
-# Conditional logic based on Ruby version
-if RUBY_VERSION >= '3.0.0'
-  gem 'hyrax', '>= 2.3'
-else
-  gem 'hyrax', '~> 4.0'
-end
+# Bulkrax supports Hyrax 2.3 through 4.x only.
+# Hyrax 5+ requires Rails 7.2 and is not yet supported.
+gem 'hyrax', '>= 2.3', '< 5.0'
 
 gem 'oai'
 gem 'pg'

--- a/app/factories/bulkrax/object_factory_interface.rb
+++ b/app/factories/bulkrax/object_factory_interface.rb
@@ -297,11 +297,11 @@ module Bulkrax
       run_callbacks :save do
         run_callbacks :create do
           if klass == Bulkrax.collection_model_class
-            create_collection(attrs)
+            @object = create_collection(attrs)
           elsif klass == Bulkrax.file_model_class
             create_file_set(attrs)
           else
-            create_work(attrs)
+            @object = create_work(attrs)
           end
         end
       end


### PR DESCRIPTION
Issue:
- https://github.com/notch8/wvu_knapsack/issues/42

**Problem:**
When importing objects (Collections, Works) using the Valkyrie backend in Hyrax, duplicate database records were being created for a single entry. This occurred because the `Bulkrax::ValkyrieObjectFactory`'s internal reference to the object (`@object`) was not updated after the primary Hyrax save transaction (e.g., `change_set.create_collection` or `change_set.create_work`) completed successfully within the `create` method.

Consequently, the subsequent call to `apply_depositor_metadata` within the same `create` method operated on the original, stale, in-memory object which still appeared as "new" (no ID, `persisted? == false`). This caused `Hyrax.persister.save(resource: @object)` within `apply_depositor_metadata` to perform a second INSERT operation, resulting in the duplicate record.

This issue was particularly noticeable when `HYRAX_FLEXIBLE=true`, likely due to differences in how flexible vs. static ChangeSets/Forms interacted with the object reference during the transaction's `sync` phase, but the underlying cause affected the Valkyrie factory regardless.

**Solution:**
Modified `Bulkrax::ObjectFactoryInterface#create` to explicitly capture the persisted resource returned by the `create_collection` and `create_work` methods (which delegate to the Hyrax transaction via `perform_transaction_for` in the Valkyrie factory) and assign it back to the `@object` instance variable.

This ensures that subsequent steps within the factory's `create` method, such as `apply_depositor_metadata`, operate on the correct, up-to-date, persisted object reference, preventing the erroneous second save.

**Impact:**
This resolves the duplicate object creation bug for users importing via the Bulkrax Valkyrie object factory. The change is contained within the shared interface but is expected to be benign for users relying on the ActiveFedora object factory, as its persistence methods typically mutated the `@object` instance in place.


## BEFORE

![image](https://github.com/user-attachments/assets/c7c5f120-7f0f-445c-b743-1ac7b892b86e)




## AFTER

![image](https://github.com/user-attachments/assets/56143f32-25b5-47a1-abbe-d67ecfacd740)

