### PR TITLE
:bug: [i43] - Allow dynamic flexible schema updates during import

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -188,13 +188,8 @@ module Bulkrax
     # @param klass the model
     # @return [Array<String>]
     def self.schema_properties(klass)
-      @schema_properties_map ||= {}
-
-      klass_key = klass.name
       schema = klass.new.singleton_class.schema || klass.schema
-      @schema_properties_map[klass_key] = schema.map { |k| k.name.to_s } unless @schema_properties_map.key?(klass_key)
-
-      @schema_properties_map[klass_key]
+      schema.map { |k| k.name.to_s }
     end
 
     def self.ordered_file_sets_for(object)


### PR DESCRIPTION


**Problem:**
When using Hyrax with flexible schemas enabled (HYRAX_FLEXIBLE=true),
uploading a new metadata profile (Hyrax::FlexibleSchema) during an
active Bulkrax import process did not immediately take effect. New metadata
fields defined in the updated profile were ignored for records processed
after the profile update but before a server/worker restart. This forced
users to restart processes to apply schema changes.

**Root Cause:**
The issue stemmed from two areas where Bulkrax components held onto
stale information about the active metadata schema:

1.  `ValkyrieObjectFactory.schema_properties`: This method cached schema
    properties using only the model class name. It did not account for
    changes in the `Hyrax::FlexibleSchema` version, leading methods like
    `field_supported?` to return outdated information based on the schema
    present when the process started.
2.  `CsvEntry#add_ingested_metadata`: This method primarily relied on the
    Bulkrax field mapping defined for the Importer. This mapping is typically
    loaded at the beginning of the import and wasn't automatically updated
    when the underlying Hyrax flexible schema changed. As a result, even if
    the factory knew a new field was valid, the CsvEntry lacked the mapping
    instruction to populate `parsed_metadata` from the corresponding CSV column.

**Solution:**
This commit addresses the issue with a two-part fix within Bulkrax:

1.  **Update `ValkyrieObjectFactory.schema_properties` Caching:**
    Modified the caching mechanism to use a composite key including both the
    model class name and the `Hyrax::FlexibleSchema.current_schema_id`. This
    ensures the cache invalidates automatically when a new schema version is
    uploaded, forcing methods like `field_supported?` to fetch and reflect
    the latest schema definition.

2.  **Enhance `CsvEntry#add_ingested_metadata`:**
    Added logic before the standard Bulkrax mapping loop. This new logic checks
    if a field present in the CSV row exists in the *latest* flexible schema
    (fetched dynamically) but is *missing* from the current Bulkrax mapping.
    If such a field is found, its data is directly added to the
    `parsed_metadata` hash, bypassing the potentially stale Bulkrax mapping
    for newly introduced schema fields.

**Outcome:**
With these changes, Bulkrax imports can now correctly recognize and populate
metadata for fields added via `Hyrax::FlexibleSchema` profile updates during
an active import run, eliminating the need for server/worker restarts to apply
schema changes.

