### PR TITLE
[i43] - Save dynamic flexible schema fields in Valkyrie imports

### DIFF
--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -104,6 +104,8 @@ ActiveRecord::Schema.define(version: 2024_12_05_212513) do
     t.integer "total_file_set_entries", default: 0
     t.integer "processed_works", default: 0
     t.integer "failed_works", default: 0
+    t.integer "processed_children", default: 0
+    t.integer "failed_children", default: 0
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 


### PR DESCRIPTION
Issue: 
- https://github.com/notch8/wvu_knapsack/issues/43

When using Hyrax with flexible schemas enabled (`HYRAX_FLEXIBLE=true`), metadata fields added dynamically via schema updates were not being saved during Bulkrax imports processed by background workers.

This occurred because while the Valkyrie model class definition could be updated dynamically within the worker to include the new attribute, the `Hyrax::Forms::ResourceForm` instance used in the transaction failed to register the dynamic attribute as 'changed' after validation. Consequently, the persistence transaction (`transaction.call(form)`) did not include the value for the dynamic field when saving the object.

This commit addresses the issue by:
1.  Retaining the mechanism (`ensure_klass_schema_is_current!`) to dynamically
    add missing attributes from the current `Hyrax::FlexibleSchema` to the
    Valkyrie model class definition within the factory.
2.  Modifying `perform_transaction_for` to explicitly iterate through the
    validated attributes hash and set each value directly on the `form`
    instance using its setter method (`form.send("#{key}=", value)`) *after*
    validation but *before* calling the transaction.

This explicit setting ensures the form object has the correct state for all attributes, including dynamic ones, bypassing the form's change-tracking issue and allowing the transaction to persist the data correctly.

Previous caching layers in `schema_properties` were also removed as part of diagnosing this issue. Debug logging has been removed, and comments cleaned up.

