### PR TITLE
I43 persist fields from schema change

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -192,7 +192,7 @@ module Bulkrax
 
       klass_key = klass.name
       schema = klass.new.singleton_class.schema || klass.schema
-      @schema_properties_map[klass_key] = schema.map { |k| k.name.to_s } unless @schema_properties_map.key?(klass_key)
+      @schema_properties_map[klass_key] = schema.map { |k| k.name.to_s } 
 
       @schema_properties_map[klass_key]
     end


### PR DESCRIPTION
Issue: 
- https://github.com/notch8/wvu_knapsack/issues/43


https://github.com/user-attachments/assets/e3843542-f2f0-4313-bc63-5f773e4f7e20





Problem:
- Metadata fields added via Hyrax's flexible schema after application start
  were not being correctly populated or saved during Bulkrax imports/updates
  using the ValkyrieObjectFactory.
- The correct values only appeared after restarting the background worker,
  indicating stale schema information was being used.

Root Cause:
- The ValkyrieObjectFactory and the underlying Hyrax forms (Reform) relied
  on model/form schema information loaded when the worker process started.
- Changes to Hyrax::FlexibleSchema were not reflected in the already-loaded
  form or model class definitions used by the running process.
- Attempts to dynamically modify the form definition at runtime conflicted
  with Reform's validation/deserialization lifecycle.

Solution:
- Modified `Bulkrax::ValkyrieObjectFactory.schema_properties` to always
  fetch the latest property list dynamically from
  `Hyrax::FlexibleSchema.definitions_for`.
- Modified `Bulkrax::ValkyrieObjectFactory#perform_transaction_for` to:
    1. Pre-populate the form with existing data.
    2. Manually assign values for dynamic fields (present in the latest
       schema and incoming attributes) directly onto the form instance
       *before* validation.
    3. Execute `form.validate(attrs)` to ensure all fields (core and
       dynamic) are validated against the form's current state.
    4. Explicitly check `form.errors` after validation and raise
       `RecordInvalid` if errors are present, halting the save.
    5. Proceed with the Hyrax transaction only if the form is valid.

This ensures that the latest flexible schema fields are correctly processed
and validated during import/update without requiring a worker restart.

Depends on related changes in:
[- hyrax/app/models/hyrax/flexible_schema.rb
](https://github.com/samvera/hyrax/pull/7085)[- hyrax/app/forms/concerns/hyrax/flexible_form_behavior.rb](https://github.com/samvera/hyrax/pull/7085)