### PR TITLE
Handle deletion & other issues with Valkyrie objects

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -166,7 +166,7 @@ module Bulkrax
 
     def delete(_user)
       obj = find
-      return false unless obj
+      raise ObjectFactoryInterface::ObjectNotFoundError, "Object not found to delete" unless obj
 
       obj.delete(eradicate: true)
     end

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -155,7 +155,7 @@ module Bulkrax
       Hyrax.query_service.find_by(id: id)
       # Because Hyrax is not a hard dependency, we need to transform the Hyrax exception into a
       # common exception so that callers can handle a generalize exception.
-    rescue Hyrax::ObjectNotFoundError => e
+    rescue Hyrax::ObjectNotFoundError, Valkyrie::Persistence::ObjectNotFoundError => e
       raise ObjectFactoryInterface::ObjectNotFoundError, e.message
     end
 
@@ -252,7 +252,7 @@ module Bulkrax
 
     def delete(user)
       obj = find
-      return false unless obj
+      raise ObjectFactoryInterface::ObjectNotFoundError, "Object not found to delete" unless obj
 
       Hyrax.persister.delete(resource: obj)
       Hyrax.index_adapter.delete(resource: obj)
@@ -381,7 +381,7 @@ module Bulkrax
     end
 
     def find_by_id
-      find(id: attributes[:id]) if attributes.key? :id
+      self.class.find(attributes[:id]) if attributes.key? :id
     end
 
     ##

--- a/app/jobs/bulkrax/delete_job.rb
+++ b/app/jobs/bulkrax/delete_job.rb
@@ -10,7 +10,9 @@ module Bulkrax
       # When we delete, we don't go through the build process.
       # However, we need the identifier to be set for the entry.
       # This enables us to delete based on the ID, not just the source_identifier.
-      if entry.parsed_metadata.nil? && entry.raw_metadata.present?
+      if entry.respond_to?(:build_metadata_for_delete) &&
+         entry.parsed_metadata.nil? &&
+         entry.raw_metadata.present?
         entry.build_metadata_for_delete
         entry.save!
       end

--- a/app/jobs/bulkrax/delete_job.rb
+++ b/app/jobs/bulkrax/delete_job.rb
@@ -6,6 +6,15 @@ module Bulkrax
 
     def perform(entry, importer_run)
       user = importer_run.importer.user
+
+      # When we delete, we don't go through the build process.
+      # However, we need the identifier to be set for the entry.
+      # This enables us to delete based on the ID, not just the source_identifier.
+      if entry.parsed_metadata.nil? && entry.raw_metadata.present?
+        entry.build_metadata_for_delete
+        entry.save!
+      end
+
       entry.factory.delete(user)
 
       # rubocop:disable Rails/SkipsModelValidations

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -85,6 +85,13 @@ module Bulkrax
       self.parsed_metadata
     end
 
+    # limited metadata is needed for delete jobs
+    def build_metadata_for_delete
+      self.parsed_metadata = {}
+      add_identifier
+      self.parsed_metadata
+    end
+
     def validate_record
       raise StandardError, 'Record not found' if record.nil?
       unless importerexporter.parser.required_elements?(record)

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -88,7 +88,8 @@ module Bulkrax
     # limited metadata is needed for delete jobs
     def build_metadata_for_delete
       self.parsed_metadata = {}
-      add_identifier
+      establish_factory_class
+      add_ingested_metadata
       self.parsed_metadata
     end
 

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -38,7 +38,7 @@ module Bulkrax
             #       We aren't right now because so many Bulkrax users are in between Fedora and Valkyrie
             if model.casecmp('collection').zero? || model.casecmp('collectionresource').zero?
               @collections << r
-            elsif model.casecmp('fileset').zero?
+            elsif model.casecmp('fileset').zero? || model.casecmp('hyrax::fileset').zero?
               @file_sets << r
             else
               @works << r

--- a/app/views/bulkrax/entries/show.html.erb
+++ b/app/views/bulkrax/entries/show.html.erb
@@ -34,18 +34,22 @@
     <p class='bulkrax-p-align'>
       <% if @importer.present? %>
 	    <%# TODO Consider how to account for Bulkrax.collection_model_class %>
-        <% factory_record = @entry.factory.find %>
-        <% if factory_record.present? %>
-          <% factory_record_class = factory_record.class %>
-          <% factory_record_class_human = factory_record_class.model_name.human %>
-          <strong><%= factory_record_class_human %> Link:</strong>
-          <% if defined?(Hyrax) && factory_record_class_human == 'Collection' %>
-            <%= link_to factory_record_class_human, hyrax.polymorphic_path(factory_record) %>
+        <% begin %>
+          <% factory_record = @entry.factory.find rescue nil %>
+          <% if factory_record.present? %>
+            <% factory_record_class = factory_record.class %>
+            <% factory_record_class_human = factory_record_class.model_name.human %>
+            <strong><%= factory_record_class_human %> Link:</strong>
+            <% if defined?(Hyrax) && factory_record_class_human == 'Collection' %>
+              <%= link_to factory_record_class_human, hyrax.polymorphic_path(factory_record) %>
+            <% else %>
+              <%= link_to factory_record_class_human, main_app.polymorphic_path(factory_record) %>
+            <% end %>
           <% else %>
-            <%= link_to factory_record_class_human, main_app.polymorphic_path(factory_record) %>
+            <strong>Item Link:</strong> Item has not yet been imported successfully
           <% end %>
-        <% else %>
-          <strong>Item Link:</strong> Item has not yet been imported successfully
+        <% rescue => e %>
+          <strong>Item Link:</strong> Unable to retrieve item (<%= e.message %>)
         <% end %>
       <% else %>
         <% record = @entry&.hyrax_record %>

--- a/spec/jobs/bulkrax/delete_work_job_spec.rb
+++ b/spec/jobs/bulkrax/delete_work_job_spec.rb
@@ -38,7 +38,6 @@ module Bulkrax
       before do
         allow(factory).to receive(:find).and_return(nil)
         allow(entry).to receive(:factory).and_return(factory)
-        allow(factory).to receive(:delete).and_raise(StandardError, "Record not found")
         allow(entry).to receive(:set_status_info)
       end
 
@@ -46,10 +45,10 @@ module Bulkrax
         # Expect the error to be raised
         expect do
           delete_work_job.perform(entry, importer_run)
-        end.to raise_error(StandardError, "Record not found")
+        end.to raise_error(Bulkrax::ObjectFactoryInterface::ObjectNotFoundError, "Object not found to delete")
 
         # Verify set_status_info was called with the error
-        expect(entry).to have_received(:set_status_info).with(instance_of(StandardError))
+        expect(entry).to have_received(:set_status_info).with(instance_of(Bulkrax::ObjectFactoryInterface::ObjectNotFoundError))
       end
 
       it 'does not increment deleted_records or decrement enqueued_records' do

--- a/spec/jobs/bulkrax/delete_work_job_spec.rb
+++ b/spec/jobs/bulkrax/delete_work_job_spec.rb
@@ -42,32 +42,32 @@ module Bulkrax
         allow(entry).to receive(:set_status_info)
       end
 
-    it 'raises an error and sets status info' do
-      # Expect the error to be raised
-      expect {
-        delete_work_job.perform(entry, importer_run)
-      }.to raise_error(StandardError, "Record not found")
+      it 'raises an error and sets status info' do
+        # Expect the error to be raised
+        expect do
+          delete_work_job.perform(entry, importer_run)
+        end.to raise_error(StandardError, "Record not found")
 
-      # Verify set_status_info was called with the error
-      expect(entry).to have_received(:set_status_info).with(instance_of(StandardError))
-    end
-
-    it 'does not increment deleted_records or decrement enqueued_records' do
-      expect(importer_run.enqueued_records).to eq(1)
-      expect(importer_run.deleted_records).to eq(0)
-
-      # Call perform but rescue the error
-      begin
-        delete_work_job.perform(entry, importer_run)
-      rescue StandardError
-        # Ignore the error
+        # Verify set_status_info was called with the error
+        expect(entry).to have_received(:set_status_info).with(instance_of(StandardError))
       end
-      importer_run.reload
 
-      # Counters should remain unchanged
-      expect(importer_run.enqueued_records).to eq(1)
-      expect(importer_run.deleted_records).to eq(0)
-    end
+      it 'does not increment deleted_records or decrement enqueued_records' do
+        expect(importer_run.enqueued_records).to eq(1)
+        expect(importer_run.deleted_records).to eq(0)
+
+        # Call perform but rescue the error
+        begin
+          delete_work_job.perform(entry, importer_run)
+        rescue StandardError
+          # Ignore the error
+        end
+        importer_run.reload
+
+        # Counters should remain unchanged
+        expect(importer_run.enqueued_records).to eq(1)
+        expect(importer_run.deleted_records).to eq(0)
+      end
     end
   end
 end

--- a/spec/models/bulkrax/oai_entry_spec.rb
+++ b/spec/models/bulkrax/oai_entry_spec.rb
@@ -109,7 +109,7 @@ module Bulkrax
         allow(entry).to receive_message_chain(:record, :header, :identifier).and_return("some_identifier")
         allow(entry).to receive_message_chain(:record, :header, :set_spec).and_return([])
         allow(entry).to receive_message_chain(:record, :metadata, :children).and_return(nodes)
-        allow(entry).to receive_message_chain(:raw_metadata, :[]).and_return({ children: [], parents: [] })
+        allow(entry).to receive_message_chain(:raw_metadata).and_return({ children: [], parents: [] })
         # Verifying that I have field mappings
         expect(entry.parser.model_field_mappings).to eq(["model"])
         entry.build_metadata
@@ -141,7 +141,7 @@ module Bulkrax
         allow(entry).to receive_message_chain(:record, :header, :identifier).and_return("some_identifier")
         allow(entry).to receive_message_chain(:record, :header, :set_spec).and_return([])
         allow(entry).to receive_message_chain(:record, :metadata, :children).and_return([])
-        allow(entry).to receive_message_chain(:raw_metadata, :[]).and_return({ children: [], parents: [] })
+        allow(entry).to receive_message_chain(:raw_metadata).and_return({ children: [], parents: [] })
         entry.build_metadata
         expect(entry.parsed_metadata['admin_set_id']).to eq 'MyString'
       end


### PR DESCRIPTION
## Summary
- fixes method `find_by_id`: This method was failing because it tried to use the find class method on an instance. This caused a silent deletion failure, where the importer reported success but the object was not deleted. It also caused the show page to be broken.
- adds another way to find the class from an entry The FactoryClassFinder did not find the class for deletions and other cases where the metadata was not parsed. This resulted in a fallback to the default work class.
- handles situations causing entry show page errors