### PR TITLE
Raise specific errors

### DIFF
--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -368,7 +368,40 @@ module Bulkrax
       Bulkrax::CsvMatcher
     end
 
+    def collection_identifiers
+      return @collection_identifiers if @collection_identifiers.present?
+
+      parent_field_mapping = self.class.parent_field(parser)
+      return [] unless parent_field_mapping.present? && record[parent_field_mapping].present?
+
+      identifiers = []
+      split_references = record[parent_field_mapping].split(Bulkrax.multi_value_element_split_on)
+      split_references.each do |c_reference|
+        matching_collection_entries = importerexporter.entries.select do |e|
+          (e.raw_metadata&.[](source_identifier) == c_reference) &&
+            e.is_a?(CsvCollectionEntry)
+        end
+        raise ::StandardError, 'Only expected to find one matching entry' if matching_collection_entries.count > 1
+        identifiers << matching_collection_entries.first&.identifier
+      end
+      @collection_identifiers = identifiers.compact.presence || []
+    end
+
+    def collections_created?
+      # TODO: look into if this method is still needed after new relationships code
+      true
+    end
+
     def find_collection_ids
+      return self.collection_ids if collections_created?
+      if collection_identifiers.present?
+        collection_identifiers.each do |collection_id|
+          c = find_collection(collection_id)
+          skip = c.blank? || self.collection_ids.include?(c.id)
+          self.collection_ids << c.id unless skip
+        end
+      end
+
       self.collection_ids
     end
 

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -372,6 +372,7 @@ module Bulkrax
 
       return @path_to_files if File.exist?(@path_to_files)
 
+      # TODO: This method silently returns nil if there is no file & no zip file
       File.join(importer_unzip_path, 'files', filename) if file? && zip?
     end
 

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -31,6 +31,11 @@ module Bulkrax
         data = described_class.read_data(path)
         expect(data.count).to eq(1)
       end
+      context 'without a path' do
+        it 'raises an error' do
+          expect { described_class.read_data(nil) }.to raise_error(CsvEntry::CsvPathError, 'CSV path empty')
+        end
+      end
     end
 
     context 'AttributeBuilderMethod.for' do
@@ -118,7 +123,7 @@ module Bulkrax
         end
 
         it 'fails and stores an error' do
-          expect { subject.build_metadata }.to raise_error(StandardError)
+          expect { subject.build_metadata }.to raise_error(CsvEntry::MissingMetadata, "Missing required elements, missing element(s) are: title")
         end
       end
 
@@ -1314,6 +1319,17 @@ module Bulkrax
         expect(entry.parsed_metadata['visibility_during_lease']).to eq('restricted')
         expect(entry.parsed_metadata['lease_expiration_date']).to eq('2054-04-19')
         expect(entry.parsed_metadata['visibility_after_lease']).to eq('open')
+      end
+    end
+    describe '#validate_record' do
+      context 'with no raw_metadata' do
+        before do
+          allow(subject).to receive(:raw_metadata).and_return(nil)
+        end
+
+        it 'raises an error' do
+          expect { subject.validate_record }.to raise_error(CsvEntry::RecordNotFound, 'Record not found')
+        end
       end
     end
   end

--- a/spec/models/bulkrax/csv_file_set_entry_spec.rb
+++ b/spec/models/bulkrax/csv_file_set_entry_spec.rb
@@ -33,15 +33,42 @@ module Bulkrax
       end
     end
 
+    describe '#validate_presence_of_parent!' do
+      context 'when parent is missing' do
+        before do
+          entry.parsed_metadata = { 'remote_files' => ['test.png'] }
+          allow(entry).to receive(:related_parents_parsed_mapping).and_return('parents')
+        end
+        it 'raises an error' do
+          # entry.validate_presence_of_parent!
+          expect { entry.validate_presence_of_parent! }.to raise_error(FileSetEntryBehavior::OrphanFileSetError, 'File set must be related to at least one work')
+        end
+      end
+    end
+
+    describe '#add_path_to_file' do
+      context 'when file is not present' do
+        subject(:entry) { described_class.new(importerexporter: FactoryBot.create(:bulkrax_importer_csv), type: "Bulkrax::CsvFileSetEntry") }
+
+        before do
+          entry.parsed_metadata = { 'file' => ['test.png'] }
+          allow(entry.parser).to receive(:importer_unzip_path).and_return('some_real_path')
+        end
+        it 'raises an error' do
+          expect { entry.add_path_to_file }.to raise_error(FileSetEntryBehavior::FilePathError, 'one or more file paths are invalid: test.png')
+        end
+      end
+    end
+
     describe '#validate_presence_of_filename!' do
       context 'when filename is missing' do
         before do
           entry.parsed_metadata = {}
         end
 
-        it 'raises a StandardError' do
+        it 'raises a FileNameError' do
           expect { entry.validate_presence_of_filename! }
-            .to raise_error(StandardError, 'File set must have a filename')
+            .to raise_error(FileSetEntryBehavior::FileNameError, 'File set must have a filename')
         end
       end
 
@@ -50,7 +77,7 @@ module Bulkrax
           entry.parsed_metadata = { 'file' => ['test.png'] }
         end
 
-        it 'does not raise a StandardError' do
+        it 'does not raise an error' do
           expect { entry.validate_presence_of_filename! }
             .not_to raise_error
         end
@@ -61,9 +88,9 @@ module Bulkrax
           entry.parsed_metadata = { 'file' => [''] }
         end
 
-        it 'raises a StandardError' do
+        it 'raises a FileNameError' do
           expect { entry.validate_presence_of_filename! }
-            .to raise_error(StandardError, 'File set must have a filename')
+            .to raise_error(FileSetEntryBehavior::FileNameError, 'File set must have a filename')
         end
       end
     end


### PR DESCRIPTION
- Raise specific errors (when they are knowable), so that we can use more targeted error handling in future.
- Add more error handling testing
- Also remove some code that has been dead for 3 years.

Existing code that rescues StandardError will still work, since all of these custom errors inherit from StandardError.