### PR TITLE
:bug: Fix: Honor tenant file size limits in Bulkrax JavaScript uploader

### DIFF
--- a/app/assets/javascripts/bulkrax/importers.js.erb
+++ b/app/assets/javascripts/bulkrax/importers.js.erb
@@ -15,7 +15,10 @@ function prepBulkrax(event) {
   // Initialize the uploader only if hyraxUploader is defined
   if (typeof $.fn.hyraxUploader === 'function') {
     // Initialize the uploader
-    $('.fileupload-bulkrax').hyraxUploader({ maxNumberOfFiles: 1 });
+    $('.fileupload-bulkrax').hyraxUploader({ 
+      maxNumberOfFiles: 1,
+      maxFileSize: <%= (defined?(Hyrax) && Hyrax.config.uploader[:maxFileSize]) || 524288000 %>
+    });
 
     // Function to toggle 'required' attribute based on uploaded files
     function toggleRequiredAttribute() {


### PR DESCRIPTION
# Summary

Fixes issue where Bulkrax's JavaScript uploader doesn't respect tenant-specific file_size_limit configuration, causing 'File is too large' errors even when the tenant limit is higher than the file size.

The original code only passed `maxNumberOfFiles: 1` to `hyraxUploader()` but ignored the `maxFileSize` configuration, causing uploads to fail against the hardcoded 500MB limit even when tenants had configured higher limits (e.g., 9GB).

## Ticket Number
- https://github.com/notch8/palni_palci_knapsack/issues/461

Related to file size limit issues in multi-tenant Hyrax/Hyku applications.

# Screenshots / Video

## BEFORE

### Default 5gb

<img width="316" height="158" alt="image" src="https://github.com/user-attachments/assets/61b9cafc-6084-444c-b240-2051232cbce7" />

<img width="2704" height="1460" alt="Screenshot 2025-09-03 at 14-46-52 New Importer __ Hyku" src="https://github.com/user-attachments/assets/9db9ca74-35ac-4618-8278-c22857cbcf58" />

## AFTER

### sets file size limit to 10gb 

<img width="586" height="182" alt="image" src="https://github.com/user-attachments/assets/07e03660-a126-4f78-8315-6bf6064990a3" />


<img width="2704" height="1378" alt="Screenshot 2025-09-03 at 14-49-03 New Importer __ Hyku" src="https://github.com/user-attachments/assets/70732fde-9970-41af-8281-53c02dcf3248" />

🎉 

<img width="1334" height="786" alt="image" src="https://github.com/user-attachments/assets/de40eec1-efee-46d1-8112-c855641a38af" />


# Expected Behavior 

- **Hyku with tenant settings**: Uses tenant-specific `file_size_limit` value
- **Hyrax applications**: Uses `Hyrax.config.uploader[:maxFileSize]` (default 500MB)  
- **Non-Hyrax applications**: Falls back to 524288000 bytes (500MB hardcoded)

Before: All uploads limited to 500MB regardless of tenant configuration
After: Uploads respect the configured file size limit hierarchy

# Sample Files

Test with files larger than 500MB but smaller than configured tenant limit to verify the fix works in Hyku.

# Notes

- Uses ERB to evaluate `Hyrax.config.uploader[:maxFileSize]` server-side to pick up tenant-specific settings
- Includes defensive check `defined?(Hyrax)` for applications that might not use Hyrax
- Maintains backward compatibility with existing Hyrax and non-Hyrax deployments
- The tenant settings override works because Hyku's `AccountSettings#configure_hyrax` updates `config.uploader[:maxFileSize]` with the tenant's `file_size_limit` value