### PR TITLE
Get uploading a FileSet working on Valkyrie 

### DIFF
--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -335,14 +335,16 @@ module Bulkrax
       nil
     end
 
+    # @note We perform the transaction against the *parent* here, because the FileSets are generated and updated in relationship with their parent, not in isolation
     def create_file_set(attrs)
       attrs = HashWithIndifferentAccess.new(attrs)
       parent_object = find_record(attributes[related_parents_parsed_mapping].first, importer_run_id).last
-      perform_transaction_for(object: parent_object, attrs: attrs) do
-        uploaded_files, file_set_params = prep_fileset_content(attrs)
+      perform_transaction_for(object: parent_object, attrs: {}) do
+        fs_attrs = attrs.merge(attributes).symbolize_keys
+        uploaded_files, = prep_fileset_content(attrs)
         transactions['change_set.update_work']
           .with_step_args(
-            'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: file_set_params },
+            'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: [fs_attrs] },
             'work_resource.save_acl' => { permissions_params: [attrs.try('visibility') || 'open'].compact }
           )
       end

--- a/app/factories/bulkrax/valkyrie_object_factory.rb
+++ b/app/factories/bulkrax/valkyrie_object_factory.rb
@@ -338,8 +338,6 @@ module Bulkrax
     def create_file_set(attrs)
       attrs = HashWithIndifferentAccess.new(attrs)
       parent_object = find_record(attributes[related_parents_parsed_mapping].first, importer_run_id).last
-      uploaded_files, file_set_params = prep_fileset_content(attrs)
-
       perform_transaction_for(object: parent_object, attrs: attrs) do
         uploaded_files, file_set_params = prep_fileset_content(attrs)
         transactions['change_set.update_work']

--- a/app/jobs/bulkrax/create_relationships_job.rb
+++ b/app/jobs/bulkrax/create_relationships_job.rb
@@ -136,6 +136,7 @@ module Bulkrax
     # When the parent is a collection, we save the relationship on each child.
     # The parent does not need to be saved, as the relationship is stored on the child.
     # but we do reindex the parent after all the children are added.
+    # rubocop:disable Layout/RescueEnsureAlignment
     def process_parent_as_collection(parent_record:, parent_identifier:)
       ActiveRecord::Base.uncached do
         Bulkrax::PendingRelationship.where(parent_id: parent_identifier, importer_run_id: @importer_run_id)
@@ -151,7 +152,6 @@ module Bulkrax
           @errors << e
         end
       end
-
       # if collection members were added, we reindex the collection
       # The collection members have already saved the relationships
       # To index the parent, we want to make sure we have the latest version of the parent,
@@ -161,6 +161,7 @@ module Bulkrax
       Bulkrax.object_factory.update_index(resources: [reloaded_parent])
       Bulkrax.object_factory.publish(event: 'object.membership.updated', object: reloaded_parent, user: @user)
     end
+    # rubocop:enable Layout/RescueEnsureAlignment
 
     # When the parent is a work, we save the relationship on the parent.
     # We prefer to save all of the member relationships and then save the parent once. Concurrent
@@ -168,6 +169,7 @@ module Bulkrax
     # record while we are adding the children to it.
     # However the locking appears to not be working so as a workaround we will save each member as we go,
     # but only index the parent once at the end.
+    # rubocop:disable Layout/RescueEnsureAlignment
     def process_parent_as_work(parent_record:, parent_identifier:)
       conditionally_acquire_lock_for(parent_record.id.to_s) do
         ActiveRecord::Base.uncached do
@@ -193,6 +195,7 @@ module Bulkrax
         end
       end
     end
+    # rubocop:enable Layout/RescueEnsureAlignment
 
     # NOTE: the child changes are saved in the object factory.
     def add_to_collection(relationship:, parent_record:, ability:)

--- a/spec/models/bulkrax/valkyrie_object_factory_spec.rb
+++ b/spec/models/bulkrax/valkyrie_object_factory_spec.rb
@@ -100,7 +100,7 @@ module Bulkrax
         stub_request(:get, %r{http://localhost:8986/rest/test.*}).to_return(status: 200, body: "", headers: {})
       end
       it 'creates transactions for the parent object' do
-        expect(valkyrie_object_factory).to receive(:perform_transaction_for).with(object: satisfy { |data| data.id == parent_id }, attrs: of_attributes).once
+        expect(valkyrie_object_factory).to receive(:perform_transaction_for).with(object: satisfy { |data| data.id == parent_id }, attrs: {}).once
 
         valkyrie_object_factory.send(:create_file_set, of_attributes)
       end

--- a/spec/models/bulkrax/valkyrie_object_factory_spec.rb
+++ b/spec/models/bulkrax/valkyrie_object_factory_spec.rb
@@ -77,14 +77,65 @@ module Bulkrax
         expect(ActiveFedora::Base).to have_received(:where).with({ "bulkrax_identifier_tesim" => "BU_Collegian-19481124" })
       end
     end
-    describe '.create_file_set' do
+    describe '#create_file_set' do
       let(:valkyrie_object_factory) do
-        described_class.new(attributes: [], source_identifier_value: 'abc123', work_identifier: '123abc', work_identifier_search_field: 'some_field_tesim')
+        described_class.new(
+          attributes: { "bulkrax_identifier" => "fs-123",
+                        "model" => "FileSet",
+                        "file" => ["spec/fixtures/csv/files/moon.jpg"],
+                        "parents" => ["gw-123"],
+                        "title" => ["Custom File Set Title"],
+                        "creator" => ["KKW"],
+                        "rights_statement" => [""],
+                        "visibility" => "restricted",
+                        "admin_set_id" => "b75a49fb-e3d6-4ac7-b1c9-c527f7471508",
+                        "uploaded_files" => [22] },
+          source_identifier_value: 'fs-123', work_identifier: :bulkrax_identifier, work_identifier_search_field: "bulkrax_identifier_tesim",
+          klass: Hyrax::FileSet, update_files: true, related_parents_parsed_mapping: "parents", importer_run_id: 123, user: FactoryBot.create(:user)
+        )
       end
-      it "raises a not implemented error, since it's not implemented" do
-        expect do
-          valkyrie_object_factory.send(:create_file_set, {})
-        end.to raise_error(NotImplementedError)
+    #   let(:importer_run) { FactoryBot.create(:importer_run) }
+      let(:custom_queries) do
+        [
+          Hyrax::CustomQueries::FindBySourceIdentifier,
+          Hyrax::CustomQueries::FindAccessControl,
+          Hyrax::CustomQueries::Navigators::FindFiles,
+          Hyrax::CustomQueries::FindFileMetadata
+        ]
+      end
+      let(:parent_work) { FactoryBot.build(:work, id: 'gw-123') }
+    #   let(:resource_converter) do
+    #     Valkyrie::Persistence::Postgres::ResourceConverter.new(
+    #       parent_work,
+    #       resource_factory: Valkyrie::Persistence::Postgres::ResourceFactory.new(
+    #         adapter: Valkyrie::Persistence::Postgres::MetadataAdapter.new
+    #       )
+    #     )
+    #   end
+      around do |example|
+        cached_file_model_class = Bulkrax.file_model_class
+        Bulkrax.file_model_class = Hyrax::FileSet
+        example.run
+        Bulkrax.file_model_class = cached_file_model_class
+      end
+      before do
+        Valkyrie::MetadataAdapter.register(Valkyrie::Persistence::Postgres::MetadataAdapter.new, :postgres_adapter)
+        Valkyrie.config.metadata_adapter = :postgres_adapter
+        custom_queries.each do |query|
+          Hyrax.query_service.custom_queries.register_query_handler(query)
+        end
+
+        allow(Hyrax.query_service).to receive(:run_query).with("          SELECT * FROM orm_resources\n          WHERE metadata -> ? ->> 0 = ?\n          LIMIT 1;\n", :bulkrax_identifier, "fs-123").and_return([nil])
+    #     stub_request(:get, "http://localhost:8985/solr/hydra-test/select?fl=id&q=_query_:%22%7B!field%20f=bulkrax_identifier_tesim%7Dfs-123%22&qt=standard&rows=1000&sort=system_create_dtsi%20asc&start=0&wt=json")
+    #       .to_return(status: 200, body: '{}', headers: {})
+    #     stub_request(:head, %r{http://localhost:8986/rest/test.*}).to_return(status: 200, body: "", headers: {})
+    #     stub_request(:get, %r{http://localhost:8986/rest/test.*}).to_return(status: 200, body: "", headers: {})
+        allow_any_instance_of(Bulkrax::DynamicRecordLookup).to receive(:find_record).with("gw-123", 123).and_return([parent_work])
+    #     allow(Valkyrie::Persistence::Postgres::ResourceConverter).to receive(:new).with(parent_work, any_args).and_return(resource_converter)
+    #     allow(resource_converter).to receive(:convert!).and_return("potato")
+      end
+      it "creates a FileSet" do
+        valkyrie_object_factory.run!
       end
     end
     describe 'Hyrax-dependent methods' do
@@ -115,7 +166,7 @@ module Bulkrax
         describe '#save!' do
           context 'without a returned object' do
             it 'raises an error' do
-              our_mock = double(Object)
+              our_mock = double(Object, {id: 123})
               allow(Hyrax.persister).to receive(:save).with(resource: our_mock).and_return(nil)
               expect do
                 described_class.save!(resource: our_mock, user: create(:user))


### PR DESCRIPTION
Refs https://github.com/notch8/hykuup_knapsack/issues/454

Use transaction on parent_object to update the parent_object with the file set in the Valkyrie adapter.

Depends on https://github.com/samvera/hyrax/pull/7213 to allow setting the :bulkrax_identifier on the FileSet, so that it can be re-found by the importer. 


